### PR TITLE
Untested change to avoid execution when packaging type is "pom". When the

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -133,6 +133,11 @@ public class GitCommitIdMojo extends AbstractMojo {
     dotGitDirectory = lookupGitDirectory();
 
     log("Running on '" + dotGitDirectory.getAbsolutePath() + "' repository...");
+    
+    if (project.getPackaging().equalsIgnoreCase("pom")) {
+      log("Skipping the execution as it is a project with packaging type: 'pom'");
+      return;
+    }
 
     try {
       properties = initProperties();


### PR DESCRIPTION
Untested change to avoid execution when packaging type is "pom". When the properties file generation is enabled and the plugin is configured to run from a root pom, an IOException is thrown and the build fails.

It is associated with the issue I reported a few minutes ago ( https://github.com/ktoso/maven-git-commit-id-plugin/issues/16 ).
