### PR TITLE
Added support for --match option.

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitDescribeConfig.java
+++ b/src/main/java/pl/project13/maven/git/GitDescribeConfig.java
@@ -56,6 +56,16 @@ public class GitDescribeConfig {
   private String dirty;
 
   /**
+   *<pre>--match glob-pattern</pre>
+   * Only consider tags matching the given pattern (can be used to avoid leaking private tags made from the repository).
+   *
+   * <b>*</b> by default, following git's behaviour.
+   *
+   * @parameter default-value="*"
+   */
+  private String match;
+
+  /**
    * <pre>--abbrev=N</pre>
    * <p>
    * Instead of using the default <em>7 hexadecimal digits</em> as the abbreviated object name,
@@ -144,9 +154,10 @@ public class GitDescribeConfig {
   public GitDescribeConfig() {
   }
 
-  public GitDescribeConfig(boolean always, String dirty, Integer abbrev, boolean forceLongFormat, boolean tags) {
+  public GitDescribeConfig(boolean always, String dirty, String match, Integer abbrev, boolean forceLongFormat, boolean tags) {
     this.always = always;
     this.dirty = dirty;
+    this.match = match;
     this.abbrev = abbrev;
     this.forceLongFormat = forceLongFormat;
     this.tags = tags;
@@ -166,6 +177,14 @@ public class GitDescribeConfig {
 
   public void setDirty(String dirty) {
     this.dirty = dirty;
+  }
+
+  public String getMatch() {
+    return match;
+  }
+
+  public void setMatch(String match) {
+    this.match = match;
   }
 
   public int getAbbrev() {

--- a/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
@@ -84,10 +84,11 @@ public class DescribeCommandOptionsTest {
   @Test
   public void apply_shouldDelegateToAllOptions() throws Exception {
     // given
-    final String DEVEL = "DEVEL";
+      final String DEVEL = "DEVEL";
+      final String MATCH = "*";
     final int ABBREV = 12;
 
-    GitDescribeConfig config = new GitDescribeConfig(true, DEVEL, ABBREV, true, true);
+    GitDescribeConfig config = new GitDescribeConfig(true, DEVEL, MATCH, ABBREV, true, true);
 
     Repository repo = mock(Repository.class);
     DescribeCommand command = DescribeCommand.on(repo);

--- a/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
@@ -114,6 +114,30 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
     assertThat(res.toString()).contains("lightweight-tag");
   }
 
+  @Test
+  public void shouldFindAnnotatedTagWithMatchOptionGiven() throws Exception {
+    // given
+
+    // HEAD
+    // lightweight-tag
+    // annotated-tag
+
+    Repository repo = git().getRepository();
+    git().reset().setMode(ResetCommand.ResetType.HARD).call();
+
+    // when
+    DescribeResult res = DescribeCommand
+        .on(repo)
+        .tags()
+        .setVerbose(true)
+        .match("annotated*")
+        .call();
+
+    // then
+    assertThat(res).isNotNull();
+
+    assertThat(res.toString()).contains("annotated-tag");
+  }
 
   /**
    * <pre>


### PR DESCRIPTION
Example:

```
  <gitDescribe>
    <match>submodule-tag-*</match>
```
