### PR TITLE
Fixed to handle git submodules

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -17,56 +17,168 @@
 
 package pl.project13.maven.git;
 
-import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.jgit.lib.Constants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Encapsulates logic to locate a valid .git directory
  * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
  */
 public class GitDirLocator {
-
+  final MavenProject mavenProject; 
+  final List<MavenProject> reactorProjects;
+  
+  public GitDirLocator(MavenProject mavenProject, List<MavenProject> reactorProjects){
+	  this.mavenProject = mavenProject;
+	  this.reactorProjects = reactorProjects;
+  }
+	
   @Nullable
-  public File lookupGitDirectory(MavenProject project, File manualyConfiguredDir) throws MojoExecutionException {
+  public File lookupGitDirectory(File manuallyConfiguredDir) {
 
-    if (isExistingDirectory(manualyConfiguredDir)) {
-      return manualyConfiguredDir;
+    if (manuallyConfiguredDir != null && manuallyConfiguredDir.exists()) {
+    	
+      // If manuallyConfiguredDir is a directory then we can use it as the git path. 
+      if (manuallyConfiguredDir.isDirectory()) {
+          return manuallyConfiguredDir;
+      }
+      
+      // If the path exists but is not a directory it might be a git submodule "gitdir" link.
+      File gitDirLinkPath = processGitDirFile(manuallyConfiguredDir);
+      
+      // If the linkPath was found from the file and it exists then use it.
+      if (isExistingDirectory(gitDirLinkPath))
+      {
+    	  return gitDirLinkPath;
+      }
+      
+      /**
+       * FIXME: I think we should fail here because a manual path was set and it was not found
+       * but I'm leaving it falling back to searching for the git path because that is the current
+       * behaviour - Unluckypixie.
+       */
     }
 
-    MavenProject mavenProject = project;
+	  return findProjectGitDirectory(); 
+  }
 
-    File dir;
-    while (mavenProject != null) {
-      dir = currentProjectGitDir(mavenProject);
+  /**
+   * Search up all the maven parent project heirarchy until a .git
+   * directory is found.
+   * 
+   * @return File the location of the .git directory or NULL if none found.
+   */
+  private File findProjectGitDirectory()
+  {
+    MavenProject project = this.mavenProject;
+    
+    while (project != null) {
+      File dir = getProjectGitDir(project);
+      
       if (isExistingDirectory(dir)) {
         return dir;
       }
 
-      if (mavenProject.getBasedir() != null) {
-        dir = new File(mavenProject.getBasedir().getParentFile(), Constants.DOT_GIT);
-        if (isExistingDirectory(dir)) {
-          return dir;
-        }
+      /**
+       * project.getParent always returns NULL for me, but if getParentArtifact returns
+       * not null then there is actually a parent - seems like a bug in maven to me.
+       */
+      if (project.getParent() == null && project.getParentArtifact() != null) {
+    	  project = getReactorParentProject(project);
+      } else {
+    	  // Get the parent, or NULL if no parent AND no parentArtifact.
+    	  project = project.getParent();
       }
-
-      mavenProject = mavenProject.getParent();
     }
+
     return null;
   }
+  
+  /**
+   * Find a project in the reactor by its artifact, I'm new to maven coding
+   * so there may be a better way to do this, it would not be necessary
+   * if project.getParent() actually worked.
+   * 
+   * @param MavenProject project
+   * @return MavenProject parent project or NULL if no parent available
+   */
+  private MavenProject getReactorParentProject(MavenProject project) {
+    Artifact parentArtifact = project.getParentArtifact();
+    
+    if (parentArtifact != null) {
+  	  for (MavenProject reactorProject : this.reactorProjects) {
+  		  if (reactorProject.getArtifactId().equals(parentArtifact.getArtifactId())){
+  			  return reactorProject;
+  		  }
+  	  }
+    }
+    
+    return null;
+  }
+  
+  /**
+   * Load a ".git" git submodule file and read the gitdir path from it.
+   * 
+   * @param file
+   * @return File object with path loaded or null
+   */
+  private File processGitDirFile(@NotNull File file) {	
+  	try {
+  	  BufferedReader reader = null; 
+      
+  	  try {
+        reader = new BufferedReader(new FileReader(file));
 
+        // There should be just one line in the file, e.g.
+        // "gitdir: /usr/local/src/parentproject/.git/modules/submodule"
+        String line = reader.readLine();
+
+        // Separate the key and the value in the string.
+        String[] parts = line.split(": ");
+        
+        // If we don't have 2 parts or if the key is not gitdir then give up.
+        if (parts.length != 2 ||  !parts[0].equals("gitdir")) {
+          return null;
+        }
+
+        // All seems ok so return the "gitdir" value read from the file.
+        return new File(parts[1]);
+      }
+      catch (FileNotFoundException e)
+      {
+        return null;
+      }
+  	  finally
+  	  {
+  	    if (reader != null)
+  	    {
+  	      reader.close();
+  	    }
+  	  }
+    }
+  	catch (IOException e)
+  	{
+      return null;
+  	}
+  }
+  
   @NotNull
-  private File currentProjectGitDir(@NotNull MavenProject mavenProject) {
+  private File getProjectGitDir(@NotNull MavenProject mavenProject) {
+    // FIXME Shouldn't this look at the dotGitDirectory property (if set) for the given project?
     return new File(mavenProject.getBasedir(), Constants.DOT_GIT);
   }
 
-  public static boolean isExistingDirectory(@Nullable File fileLocation) {
+  public boolean isExistingDirectory(@Nullable File fileLocation) {
     return fileLocation != null && fileLocation.exists() && fileLocation.isDirectory();
   }
-
-
 }


### PR DESCRIPTION
Hi,

I have a project which heavily uses git submodules (around 80) and I wanted the branch name from each submodule to use in the name of the package for the submodule.  I got this working many months back with an old version of your plugin but the recent changes to git have changed the way .git directories work for git submodules (they are now a file with a path to where the actual directory is), I have been putting off upgrading the version of git my team was using but it has now become an issue so I have updated your plugin to support the new git submodule format.

That was the primary purpose of my commit but I have also done a couple of other things (hope you don't mind!) ...

1) Slightly changed the logging so that there is a "alwaysLog" and "log" function.  The always log function logs messages even when verbose is false and the "log" only when verbose is true.  I have made the path to the git directory and the loaded properties always log now (thought it's easy to change if you disagree).
2) The new feature to inject the properties into reactor projects really slows down my build (I have 80 is projects and have to run the plugin on each one).   So I have added a "injectAllReactorProjects" parameter (which defaults to the current behaviour of "true").  If you set that to false it only injects into the current project like it used to.
3) As part of the git submodule fix I discovered that the searching of the heirarchy of projects for the .git directory simply does not work (I have a couple of poms in a heirarchy of directories that share one .git project and it didn't work with them).  This seems to be down to project.getProject() always returning NULL.  I have added some code so that if getParent() returns NULL but getParentArtifact() does not then I search the reactor projects for the one that matches the parentArtifact and use that.  I think the fact that getParent() returns NULL is a bug in Maven so this is kinda a workaround and if it did return a project that one would be used.

All of the changes (apart from the log verbosity change) should give the same current behaviour with their default settings.  I have tested the plugin with git 1.7 and git 1.9 (between those two the git directory format was changed) and it works fine for me with both.  If you accept this plugin I would appreciate if you could get it up into the maven repos (as 2.15?) asap so I can update my projects to use this version!
