### PR TITLE
Changes default directory for git properties

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -468,7 +468,7 @@ public class GitCommitIdMojo extends AbstractMojo {
 
   void generatePropertiesFile(@NotNull Properties properties, String generateGitPropertiesFilename) throws IOException {
     FileWriter fileWriter = null;
-    File gitPropsFile = new File(project.getBasedir(), generateGitPropertiesFilename);
+    File gitPropsFile = new File(generateGitPropertiesFilename);
     try {
       Files.createParentDirs(gitPropsFile);
 

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -143,7 +143,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     setProjectToExecuteMojoIn(targetProject);
     alterMojoSettings("generateGitPropertiesFile", true);
-    alterMojoSettings("generateGitPropertiesFilename", targetFilePath);
+    alterMojoSettings("generateGitPropertiesFilename", expectedFile.getAbsolutePath());
 
     // when
     try {


### PR DESCRIPTION
Maven best practice is that every file under src/ should be under version control.

So, by default, the plugin should generate git.properties under ${project.build.outputDirectory} which is the output directory for src/main/resources.
