### PR TITLE
allow git.branch to return accurate information from Jenkins/Hudson jobs

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -530,18 +530,28 @@ public class GitCommitIdMojo extends AbstractMojo {
     return !directoryExists(fileLocation);
   }
   
+  /**
+   * If running within Jenkins/Hudosn, honor the branch name passed via GIT_BRANCH env var.  This
+   * is necessary because Jenkins/Hudson alwways invoke build in a detached head state.
+   * 
+   * @param git
+   * @return results of git.getBranch() or, if in Jenkins/Hudson, value of GIT_BRANCH
+   */
   protected String determineBranchName(Repository git) throws IOException {
+	  Map<String,String> env = System.getenv();
+	  return determineBranchName(git,env);
+  }
+  
+  protected String determineBranchName(Repository git, Map<String,String> env) throws IOException {
 	  String branch = git.getBranch();
 	  
 	  // Special processing if we're in Jenkins/Hudson
-	  Map<String,String> env = System.getenv();
 	  if (env.containsKey("HUDSON_URL") || env.containsKey("JENKINS_URL")) {
 		  String branchName = env.get("GIT_BRANCH");
 		  if (branchName!=null && branchName.length()>0) {
 			  branch=branchName;
 		  }
 	  }
-	  
 	  return branch;
   }
 

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -22,11 +22,16 @@ import org.eclipse.jgit.lib.Repository;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.Maps;
+
 import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * I'm not a big fan of this test - let's move to integration test from now on.
@@ -90,4 +95,39 @@ public class GitCommitIdMojoTest {
     verify(mojo, never()).putGitDescribe(any(Properties.class), any(Repository.class));
   }
 
+  @Test
+  public void shouldUseJenkinsBranchInfoWhenAvailable() throws IOException {
+	  Repository git = mock(Repository.class);
+	  Map<String,String> env = Maps.newHashMap();
+	  
+	  String detachedHeadSHA1 = "16bb801934e652f5e291a003db05e364d83fba25";
+	  String ciUrl = "http://myciserver.com";
+	  
+	  when(git.getBranch()).thenReturn(detachedHeadSHA1);
+	  
+	  // In a detached head state, getBranch() will return the SHA1...standard behavior
+	  assertEquals(detachedHeadSHA1, mojo.determineBranchName(git, env));
+	  
+	  // Again, SHA1 will be returned if we're in jenkins, but GIT_BRANCH is not set
+	  env.put("JENKINS_URL", "http://myjenkinsserver.com");
+	  assertEquals(detachedHeadSHA1, mojo.determineBranchName(git, env));
+	  
+	  // Now set GIT_BRANCH too and see that the branch name from env var is returned
+	  env.clear();
+	  env.put("JENKINS_URL", ciUrl);
+	  env.put("GIT_BRANCH", "mybranch");
+	  assertEquals("mybranch", mojo.determineBranchName(git, env));
+	  
+	  
+	  // Same, but for hudson
+	  env.clear();
+	  env.put("GIT_BRANCH", "mybranch");
+	  env.put("HUDSON_URL", ciUrl);
+	  assertEquals("mybranch", mojo.determineBranchName(git, env));
+	  
+	  // GIT_BRANCH but no HUDSON_URL or JENKINS_URL
+	  env.clear();
+	  env.put("GIT_BRANCH", "mybranch");
+	  assertEquals(detachedHeadSHA1, mojo.determineBranchName(git, env));
+  }
 }


### PR DESCRIPTION
It is a known issue that git.branch is not populated with the actual branch when executed within Jenkins/Hudson.

This simple patch checks to see if the current execution is within Hudson or Jenkins, and falls back to the env var, GIT_BRANCH if it is set. 

Since the Jenkins Git Plugin populates this environment variable, the "correct" value will be set.
