### PR TITLE
Changed maven deprecated method to new one

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -77,7 +77,7 @@ public class GitCommitIdMojo extends AbstractMojo {
   /**
    * The maven project.
    *
-   * @parameter expression="${project}"
+   * @parameter property="project"
    * @readonly
    */
   @SuppressWarnings("UnusedDeclaration")
@@ -86,7 +86,7 @@ public class GitCommitIdMojo extends AbstractMojo {
   /**
    * Contains the full list of projects in the reactor.
    *
-   * @parameter expression="${reactorProjects}"
+   * @parameter property="reactorProjects"
    * @readonly
    */
   @SuppressWarnings("UnusedDeclaration")
@@ -118,7 +118,7 @@ public class GitCommitIdMojo extends AbstractMojo {
    * Specifies whether the execution in pom projects should be skipped.
    * Override this value to false if you want to force the plugin to run on 'pom' packaged projects.
    *
-   * @parameter expression="${git.skipPoms}" default-value="true"
+   * @parameter property="git.skipPoms" default-value="true"
    */
   @SuppressWarnings("UnusedDeclaration")
   private boolean skipPoms;


### PR DESCRIPTION
- Working without warnings on maven 3.1 and java 1.7.0_45

Before emmited warning on compile:
[INFO] Applying mojo extractor for language: java
[WARNING] pl.project13.maven.git.GitCommitIdMojo#project:
[WARNING]   The syntax
[WARNING]     @parameter expression="${property}"
[WARNING]   is deprecated, please use
[WARNING]     @parameter property="property"
[WARNING]   instead.
[WARNING] pl.project13.maven.git.GitCommitIdMojo#reactorProjects:
[WARNING]   The syntax
[WARNING]     @parameter expression="${property}"
[WARNING]   is deprecated, please use
[WARNING]     @parameter property="property"
[WARNING]   instead.
[WARNING] pl.project13.maven.git.GitCommitIdMojo#skipPoms:
[WARNING]   The syntax
[WARNING]     @parameter expression="${property}"
[WARNING]   is deprecated, please use
[WARNING]     @parameter property="property"
[WARNING]   instead.
