### PR TITLE
Spring Boot added to "notable users"

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ Notable happy users
 
 * neo4j
 * foundationdb.com
+* [Spring Boot](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-maven)
 * others I know of but shouldn't tell ;-)
 * many others I don't know of
 


### PR DESCRIPTION
They're mentioning it explicitly in the "Sensible plugin configuration" point in the documentation (http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-maven)
