### PR TITLE
Fixed bug when using forceLongFormat on gitDescribe

### DIFF
--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -180,7 +180,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   public DescribeCommand forceLongFormat(@Nullable Boolean forceLongFormat) {
     if (forceLongFormat != null) {
       this.forceLongFormat = forceLongFormat;
-      log("--long = %s", forceLongFormat);
+      log("--long =", forceLongFormat);
     }
     return this;
   }
@@ -312,9 +312,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     // check if dirty
     boolean dirty = findDirtyState(repo);
 
-    if (hasTags(headCommit, tagObjectIdToName)) {
+    if (hasTags(headCommit, tagObjectIdToName) && !forceLongFormat) {
       String tagName = tagObjectIdToName.get(headCommit).iterator().next();
-      log("The commit we're on is a Tag ([",tagName,"]), returning.");
+      log("The commit we're on is a Tag ([",tagName,"]) and forceLongFormat == false, returning.");
 
       return new DescribeResult(tagName, dirty, dirtyOption);
     }
@@ -351,7 +351,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
           .withCommitIdAbbrev(abbrev);
 
     } else if (howFarFromWhichTag.first > 0 || forceLongFormat) {
-      return new DescribeResult(objectReader, howFarFromWhichTag.second, howFarFromWhichTag.first, headCommitId, dirty, dirtyOption)
+      return new DescribeResult(objectReader, howFarFromWhichTag.second, howFarFromWhichTag.first, headCommitId, dirty, dirtyOption, forceLongFormat)
           .withCommitIdAbbrev(abbrev); // we're a bit away from a tag
 
     } else if (howFarFromWhichTag.first == 0) {

--- a/src/main/java/pl/project13/jgit/DescribeResult.java
+++ b/src/main/java/pl/project13/jgit/DescribeResult.java
@@ -49,6 +49,8 @@ public class DescribeResult {
   private boolean dirty;
   private String dirtyMarker;
 
+  private boolean forceLongFormat;
+
   private ObjectReader objectReader;
 
   public static final DescribeResult EMPTY = new DescribeResult("");
@@ -58,7 +60,7 @@ public class DescribeResult {
   }
 
   public DescribeResult(@NotNull ObjectReader objectReader, String tagName, int commitsAwayFromTag, @Nullable ObjectId commitId) {
-    this(objectReader, tagName, commitsAwayFromTag, commitId, false, Optional.<String>absent());
+    this(objectReader, tagName, commitsAwayFromTag, commitId, false, Optional.<String>absent(), false);
   }
 
   public DescribeResult(@NotNull ObjectReader objectReader, @NotNull ObjectId commitId) {
@@ -69,13 +71,14 @@ public class DescribeResult {
   }
 
   public DescribeResult(@NotNull ObjectReader objectReader, String tagName, int commitsAwayFromTag, ObjectId commitId, boolean dirty, String dirtyMarker) {
-    this(objectReader, tagName, commitsAwayFromTag, commitId, dirty, Optional.of(dirtyMarker));
+    this(objectReader, tagName, commitsAwayFromTag, commitId, dirty, Optional.of(dirtyMarker), false);
   }
 
-  public DescribeResult(@NotNull ObjectReader objectReader, String tagName, int commitsAwayFromTag, ObjectId commitId, boolean dirty, Optional<String> dirtyMarker) {
+  public DescribeResult(@NotNull ObjectReader objectReader, String tagName, int commitsAwayFromTag, ObjectId commitId, boolean dirty, Optional<String> dirtyMarker, boolean forceLongFormat) {
     this(objectReader, commitId, dirty, dirtyMarker);
     this.tagName = Optional.of(tagName);
     this.commitsAwayFromTag = commitsAwayFromTag;
+    this.forceLongFormat = forceLongFormat;
   }
 
   public DescribeResult(@NotNull ObjectReader objectReader, @NotNull ObjectId commitId, boolean dirty, @NotNull Optional<String> dirtyMarker) {
@@ -145,6 +148,9 @@ public class DescribeResult {
 
   @Nullable
   public String commitsAwayFromTag() {
+    if (forceLongFormat) {
+      return String.valueOf(commitsAwayFromTag);
+    }
     return commitsAwayFromTag == 0 ? null : String.valueOf(commitsAwayFromTag);
   }
 


### PR DESCRIPTION
Setting "forceLongFormat" to true in the "gitDescribe" section of the plugin configuration does not have the desired effect and will not force the long format of the "git.commit.id.describe" property. I've created two new test methods in GitCommitIdMojoIntegrationTest that exposes the bug and made changes that should fix the bug. 

This pull request also includes two changes to two log statements in DescribeCommand. The first fixes a bug and the second adds some extra info.
