### PR TITLE
added git.branch.classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <!-- true is default here, it prints some more information during the build -->
                     <verbose>true</verbose>
 
+					<!-- @since 2.1.9 -->
+					<!-- 
+                        false is default here, if set to true it uses native GIT excutable for 
+						better performance (it must be installed in system and available in system PATH) 
+
+                    -->
+					<useNativeGit>false</useNativeGit>
+
                     <!--
                         If you'd like to tell the plugin where your .git directory is,
                         use this setting, otherwise we'll perform a search trying to
@@ -538,6 +546,7 @@ Notable happy users
 * [neo4j](http://www.neo4j.org/) graph database
 * foundationdb.com
 * [Spring Boot](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-git-commit-information)
+* Akamai
 * others I know of but shouldn't tell ;-)
 * many others I don't know of
 

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -29,7 +29,11 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.*;
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -242,6 +246,17 @@ public class GitCommitIdMojo extends AbstractMojo {
   private boolean failOnUnableToExtractRepoInfo;
 
   /**
+   * By default the plugin will use a jgit implementation as a source of a information about the repository. You can
+   * use a native GIT executable to fetch information about the repository, witch is in most cases faster but requires
+   * a git executable to be installed in system.
+   *
+   * @parameter default-value="false"
+   * @since 2.1.9
+   */
+
+  private boolean useNativeGit;
+
+  /**
    * Skip the plugin execution.
    *
    * @parameter default-value="false"
@@ -291,15 +306,17 @@ public class GitCommitIdMojo extends AbstractMojo {
       return;
     }
 
-    dotGitDirectory = lookupGitDirectory();
-    throwWhenRequiredDirectoryNotFound(dotGitDirectory, failOnNoGitDirectory, ".git directory could not be found! Please specify a valid [dotGitDirectory] in your pom.xml");
+    if (!useNativeGit) {
+      dotGitDirectory = lookupGitDirectory();
+      throwWhenRequiredDirectoryNotFound(dotGitDirectory, failOnNoGitDirectory, ".git directory could not be found! Please specify a valid [dotGitDirectory] in your pom.xml");
 
-    if (dotGitDirectory != null) {
-      log("dotGitDirectory", dotGitDirectory.getAbsolutePath());
-    } else {
-      log("dotGitDirectory is null, aborting execution!");
-      return;
-    }
+      if (dotGitDirectory != null) {
+        log("dotGitDirectory", dotGitDirectory.getAbsolutePath());
+      } else {
+        log("dotGitDirectory is null, aborting execution!");
+        return;
+      }
+	}
 
     try {
       properties = initProperties();
@@ -422,6 +439,26 @@ public class GitCommitIdMojo extends AbstractMojo {
   }
 
   void loadGitData(@NotNull Properties properties) throws IOException, MojoExecutionException {
+    if (useNativeGit) {
+      loadGitDataWithNativeGit(properties);
+    }else{
+      loadGitDataWithJGit(properties);
+    }
+  }
+
+  void loadGitDataWithNativeGit(@NotNull Properties properties) throws IOException, MojoExecutionException {
+    NativeGitProvider gitProvider = new NativeGitProvider(dateFormat);
+    File basedir = project.getBasedir().getCanonicalFile();
+    Map<String, String> loadedData;
+
+    loadedData = gitProvider.loadGitData(basedir);
+    
+    for (Map.Entry<String, String> entry : loadedData.entrySet()) {
+      put(properties, entry.getKey(), entry.getValue());
+    }
+  }
+
+  void loadGitDataWithJGit(@NotNull Properties properties) throws IOException, MojoExecutionException {
     Repository git = getGitRepository();
     ObjectReader objectReader = git.newObjectReader();
 

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -1,0 +1,218 @@
+package pl.project13.maven.git;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Scanner;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import static java.nio.charset.Charset.defaultCharset;
+
+/**
+*
+* @author Krzysztof Suszyński <krzysztof.suszynski@gmail.com>
+*/
+public class NativeGitProvider {
+
+  private transient CliRunner runner;
+
+  private static final String FORMAT;
+
+  private static final Map<String, String> PARSE_MAP;
+
+  private String dateFormat;
+
+  private static final int REMOTE_COLS = 3;
+
+  static {
+    String fileName = "/git-log-format.xml";
+    InputStream inputStream = NativeGitProvider.class.getResourceAsStream(fileName);
+    FORMAT = convertStreamToString(inputStream);
+    PARSE_MAP = new LinkedHashMap<String, String>();
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_ID, "commit/hash");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_ID_ABBREV, "commit/abbr");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_AUTHOR_NAME, "committer/name");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_AUTHOR_EMAIL, "committer/email");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_MESSAGE_SHORT, "commit/subject");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_MESSAGE_FULL, "commit/body");
+    PARSE_MAP.put(GitCommitIdMojo.COMMIT_TIME, "committer/date");
+    PARSE_MAP.put(GitCommitIdMojo.BUILD_AUTHOR_NAME, "author/name");
+    PARSE_MAP.put(GitCommitIdMojo.BUILD_AUTHOR_EMAIL, "author/email");
+  }
+
+  public NativeGitProvider(CliRunner runner, String dateFormat) {
+    this.runner = runner;
+    this.dateFormat = dateFormat;
+  }
+
+  public NativeGitProvider(String dateFormat) {
+    this.dateFormat = dateFormat;
+  }
+
+  /**
+   * Loads a git repository information using native git executable.
+   */
+  public Map<String, String> loadGitData(File directory) throws MojoExecutionException {
+    File canonical;
+    try{
+      canonical = directory.getCanonicalFile();
+    } catch (IOException ex) {
+      throw new MojoExecutionException("Passed a invalid directory, not a GIT repository: " + directory, ex);
+	}
+
+    try {
+      Map<String, String> map = new LinkedHashMap<String, String>();
+      map.put(GitCommitIdMojo.COMMIT_DESCRIBE, tryToRunGitCommand(canonical, "describe --tags", null));
+      map.put(GitCommitIdMojo.BRANCH, getBranch(canonical));
+      map.put(GitCommitIdMojo.REMOTE_ORIGIN_URL, getOriginRemote(canonical));
+      String format = FORMAT.replaceFirst("<\\?xml.+\\?>", "").replaceAll("\\s+", "");
+      String logCommand = String.format("log -1 --format=%s", format);
+      String xml = runGitCommand(canonical, logCommand);
+      readFromFormatedXml(map, xml);
+      return map;
+    } catch (Exception ex) {
+      throw new MojoExecutionException("Unsupported GIT output - has it changed?!", ex);
+    }
+  }
+
+  private String getOriginRemote(File directory) throws IOException, MojoExecutionException {
+    String remotes = runGitCommand(directory, "remote -v");
+    for (String line : remotes.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.startsWith("origin")) {
+        String[] splited = trimmed.split("\\s+");
+        if (splited.length != REMOTE_COLS) {
+          throw new MojoExecutionException("Unsupported GIT output - verbose remote address:" + line);
+        }
+        return splited[1];
+      }
+    }
+    return null;
+  }
+
+  private String runGitCommand(File directory, String gitCommand) throws MojoExecutionException {
+    try {
+      String env = System.getenv("GIT_PATH");
+      String exec = (env == null) ? "git" : env;
+      String command = String.format("%s %s", exec, gitCommand);
+      return getRunner().run(directory, command).trim();
+    }catch(IOException ex) {
+      throw new MojoExecutionException("Could not run GIT command - GIT is not installed or not exists in system path? " + "Tried to run: " + gitCommand, ex);
+    }
+  }
+
+  private String tryToRunGitCommand(File directory, String gitCommand, String defaultValue) {
+    String retValue;
+    try {
+      retValue = runGitCommand(directory, gitCommand);
+    } catch (MojoExecutionException ex) {
+      retValue = defaultValue;
+    }
+    return retValue;
+  }
+
+  private CliRunner getRunner() {
+    if (runner == null) {
+      runner = new Runner();
+    }
+    return runner;
+  }
+
+  private void readFromFormatedXml(Map<String, String> map, String xml) throws MojoExecutionException {
+    try {
+      DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder builder = builderFactory.newDocumentBuilder();
+      String withProlog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + xml;
+      ByteArrayInputStream bais = new ByteArrayInputStream(withProlog.getBytes(defaultCharset()));
+      Document document = builder.parse(bais);
+      XPath xPath = XPathFactory.newInstance().newXPath();
+      for (Map.Entry<String, String> entry : PARSE_MAP.entrySet()) {
+        String propertyName = entry.getKey();
+        String path = entry.getValue();
+        String value = xPath.compile("/props/" + path).evaluate(document);
+        map.put(propertyName, postprocesValue(value, propertyName));
+      }
+    } catch (Exception ex) {
+      throw new MojoExecutionException("Something went wrong readingTheFormatedXml.", ex);
+    }
+  }
+
+  private String getBranch(File canonical) {
+    String branch = tryToRunGitCommand(canonical, "symbolic-ref HEAD", null);
+    if (branch != null) {
+      branch = branch.replace("refs/heads/", "");
+    }
+    return branch;
+  }
+
+  private String postprocesValue(String value, String propertyName) throws ParseException {
+    if (propertyName.equals(GitCommitIdMojo.COMMIT_TIME)) {
+      SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US);
+      Date date = parser.parse(value);
+      SimpleDateFormat smf = new SimpleDateFormat(dateFormat, Locale.US);
+      return smf.format(date);
+    } else {
+      return value;
+    }
+  }
+
+
+  public interface CliRunner {
+    String run(File directory, String command) throws IOException;
+  }
+
+  protected static class Runner implements CliRunner {
+    @Override
+    public String run(File directory, String command) throws IOException {
+      try {
+        ProcessBuilder builder = new ProcessBuilder(command.split("\\s"));
+        Process proc = builder.directory(directory).start();
+        proc.waitFor();
+        String output = convertStreamToString(proc.getInputStream());
+        if (proc.exitValue() != 0) {
+          String message = String.format("Git command exited with invalid status [%d]: `%s`", proc.exitValue(),
+                  output);
+          throw new IOException(message);
+        }
+        return output;
+      } catch (InterruptedException ex) {
+        throw new IOException(ex);
+      }
+    }
+  }
+
+  private static String convertStreamToString(InputStream inputStream) {
+    if(inputStream == null){
+      IllegalArgumentException e = new IllegalArgumentException("Something went wrong InputStream is null");
+      e.printStackTrace();
+      throw e;
+    }
+    Scanner scanner = new Scanner(inputStream).useDelimiter("\\A");
+    String nextContent = "";
+    try{
+      if(scanner.hasNext()){
+        nextContent = scanner.next();
+      }
+    }catch(Exception e){
+      e.printStackTrace();
+	}finally{
+      scanner.close();
+    }
+    return nextContent;
+  }
+}

--- a/src/main/resources/git-log-format.xml
+++ b/src/main/resources/git-log-format.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<props>
+  <commit>
+    <abbr><![CDATA[%h]]></abbr>
+    <hash><![CDATA[%H]]></hash>
+    <subject><![CDATA[%s]]></subject>
+    <body><![CDATA[%b]]></body>
+  </commit>
+  <committer>
+    <name><![CDATA[%cn]]></name>
+    <email><![CDATA[%ce]]></email>
+    <date><![CDATA[%ci]]></date>
+  </committer>
+  <author>
+    <name><![CDATA[%an]]></name>
+    <email><![CDATA[%ae]]></email>
+    <date><![CDATA[%ai]]></date>
+  </author>
+</props>

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -38,6 +38,18 @@ import static org.fest.assertions.MapAssert.entry;
 import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
+  @Test
+
+  public void shouldResolvePropertiesUsingNativeGitForNonPomProject() throws Exception {
+    mavenSandbox.withParentProject("my-jar-project", "jar").withNoChildProject().withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create(CleanUp.CLEANUP_FIRST);
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    alterMojoSettings("useNativeGit", true);
+
+    mojo.execute();
+    assertGitPropertiesPresentInProject(targetProject.getProperties());
+  }
+
 
   @Test
   public void shouldResolvePropertiesOnDefaultSettingsForNonPomProject() throws Exception {

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -71,6 +71,7 @@ public abstract class GitIntegrationTest {
     mojoDefaults.put("prefix", "git");
     mojoDefaults.put("dateFormat", "dd.MM.yyyy '@' HH:mm:ss z");
     mojoDefaults.put("failOnNoGitDirectory", true);
+    mojoDefaults.put("useNativeGit", false);
     for (Map.Entry<String, Object> entry : mojoDefaults.entrySet()) {
       setInternalState(mojo, entry.getKey(), entry.getValue());
     }

--- a/src/test/java/pl/project13/maven/git/NativeGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeGitProviderTest.java
@@ -1,0 +1,164 @@
+package pl.project13.maven.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import org.fest.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.FileNotFoundException;
+
+import static org.junit.Assert.*;
+
+/**
+*
+* @author Krzysztof Suszyński <krzysztof.suszynski@gmail.com>
+*/
+public class NativeGitProviderTest {
+
+  private File directory;
+
+  @Before
+  public void setUp() {
+    directory = new File(System.getProperty("java.io.tmpdir"));
+  }
+
+  private String loadSample(String sample) {
+    String fileName = "/" + sample + ".xml";
+    try{
+      InputStream stream = this.getClass().getResourceAsStream(fileName);
+      if(stream == null){
+        throw new FileNotFoundException("FAILED TO OPEN " + fileName);
+      }
+      return convertStreamToString(stream).replaceFirst("<\\?xml.+\\?>", "").replaceAll(">\\s+<", "><");
+    }catch(Exception e){
+      e.printStackTrace();
+    }
+    return "";
+  }
+
+  private static String convertStreamToString(InputStream inputStream) {
+    Scanner scanner = new Scanner(inputStream).useDelimiter("\\A");
+    return scanner.hasNext() ? scanner.next() : "";
+  }
+
+  private Map<String, String> getDefaultTestData(){
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("git describe --tags", "v0.0.3-2557-gd79f2d5");
+    map.put("git symbolic-ref HEAD", "refs/heads/master");
+    map.put("git log -1 --format=", loadSample("sample-onbranch-with-tags"));
+    map.put("git remote -v", "origin https://git.example.org/sample-project.git (fetch)\n"
+            + "origin https://git.example.org/sample-project.git (push)");
+    return map;
+  }
+
+  private String[] getDefaultExpectedKeys(){
+    String[] expectedKeys = Arrays.array(
+            GitCommitIdMojo.COMMIT_DESCRIBE,
+            GitCommitIdMojo.BRANCH,
+            GitCommitIdMojo.REMOTE_ORIGIN_URL,
+            GitCommitIdMojo.COMMIT_ID,
+            GitCommitIdMojo.COMMIT_ID_ABBREV,
+            GitCommitIdMojo.COMMIT_AUTHOR_NAME,
+            GitCommitIdMojo.COMMIT_AUTHOR_EMAIL,
+            GitCommitIdMojo.COMMIT_MESSAGE_SHORT,
+            GitCommitIdMojo.COMMIT_MESSAGE_FULL,
+            GitCommitIdMojo.COMMIT_TIME,
+            GitCommitIdMojo.BUILD_AUTHOR_NAME,
+            GitCommitIdMojo.BUILD_AUTHOR_EMAIL
+    );
+	return expectedKeys;
+  }
+ 
+  private String[] getDefaultExpectedValue(String expectedGitTag, String expectedGitBranch){
+    String[] expectedValues = Arrays.array(
+            expectedGitTag,
+            expectedGitBranch,
+            "https://git.example.org/sample-project.git",
+            "d79f2d589079c591852ee610135ecd3acb6faf0c",
+            "d79f2d5",
+            "Krzysztof Suszyński",
+            "krzysztof.suszynski@example.org",
+            "A sample git subject line",
+            "A sample git body contents.\n"
+            + "A other sample git body contents. Even with XML tags: <3 <xml />.",
+            "04.02.2014 @ 14:53:35 CET",
+            "Jan Kowalski",
+            "jan.kowalski@example.org"
+    );
+    return expectedValues;
+  }
+
+  /**
+   * Test of loadGitData method, of class NativeGitProvider.
+   */
+  @Test
+  public void testLoadGitData() throws Exception {
+    Map<String, String> map = getDefaultTestData();
+    FakeRunner runner = new FakeRunner(map);
+    NativeGitProvider instance = new NativeGitProvider(runner, "dd.MM.yyyy '@' HH:mm:ss z");
+    Map<String, String> result = instance.loadGitData(directory);
+    String[] expectedKeys = getDefaultExpectedKeys();
+    String[] expectedValues = getDefaultExpectedValue("v0.0.3-2557-gd79f2d5","master");
+    assertArrayEquals(expectedKeys, result.keySet().toArray());
+    assertArrayEquals(expectedValues, result.values().toArray());
+  }
+
+  /**
+   * Test of loadGitData method, of class NativeGitProvider.
+   */
+  @Test
+  public void testLoadGitDataDetachedWithTags() throws Exception {
+    Map<String, String> map = getDefaultTestData();
+    FakeRunner runner = new FakeRunner(map);
+    NativeGitProvider instance = new NativeGitProvider(runner, "dd.MM.yyyy '@' HH:mm:ss z");
+    Map<String, String> result = instance.loadGitData(directory);
+    String[] expectedKeys = getDefaultExpectedKeys();
+    String[] expectedValues = getDefaultExpectedValue("v0.0.3-2557-gd79f2d5","master");
+    assertArrayEquals(expectedKeys, result.keySet().toArray());
+    assertArrayEquals(expectedValues, result.values().toArray());
+  }
+
+  /**
+   * Test of loadGitData method, of class NativeGitProvider.
+   */
+  @Test
+  public void testLoadGitDataDetachedWithoutTags() throws Exception {
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("git log -1 --format=", loadSample("sample-onbranch-with-tags"));
+    map.put("git remote -v", "origin https://git.example.org/sample-project.git (fetch)\n"
+            + "origin https://git.example.org/sample-project.git (push)");
+    FakeRunner runner = new FakeRunner(map);
+    NativeGitProvider instance = new NativeGitProvider(runner, "dd.MM.yyyy '@' HH:mm:ss z");
+    Map<String, String> result = instance.loadGitData(directory);
+    String[] expectedKeys = getDefaultExpectedKeys();
+    String[] expectedValues = getDefaultExpectedValue(null,null);
+    assertArrayEquals(expectedKeys, result.keySet().toArray());
+    assertArrayEquals(expectedValues, result.values().toArray());
+  }
+
+  private class FakeRunner implements NativeGitProvider.CliRunner {
+    private Map<String, String> map;
+
+    public FakeRunner(Map<String, String> map) {
+      this.map = map;
+    }
+
+    @Override
+    public String run(File directory, String command) throws IOException {
+      if (command == null) {
+        throw new IOException("Can not run `null` command");
+      }
+      for (Map.Entry<String, String> entry : map.entrySet()) {
+        if (command.trim().contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      throw new IOException(String.format("Unknown command: `%s`", command));
+    }
+  }
+
+}

--- a/src/test/resources/sample-onbranch-with-tags.xml
+++ b/src/test/resources/sample-onbranch-with-tags.xml
@@ -1,0 +1,19 @@
+<props>
+  <commit>
+    <abbr><![CDATA[d79f2d5]]></abbr>
+    <hash><![CDATA[d79f2d589079c591852ee610135ecd3acb6faf0c]]></hash>
+    <subject><![CDATA[A sample git subject line]]></subject>
+    <body><![CDATA[A sample git body contents.
+A other sample git body contents. Even with XML tags: <3 <xml />.]]></body>
+  </commit>
+  <committer>
+    <name><![CDATA[Krzysztof Suszyński]]></name>
+    <email><![CDATA[krzysztof.suszynski@example.org]]></email>
+    <date><![CDATA[2014-02-04 14:53:35 +0100]]></date>
+  </committer>
+  <author>
+    <name><![CDATA[Jan Kowalski]]></name>
+    <email><![CDATA[jan.kowalski@example.org]]></email>
+    <date><![CDATA[2014-02-01 12:33:45 +0100]]></date>
+  </author>
+</props>


### PR DESCRIPTION
added "git.branch.classifier" property that defaults to "" (empty string) for "master" but is otherwise equal to git.branch. Therefore, it can easily be used as classifier:

```
<plugin>
  <artifactId>maven-jar-plugin</artifactId>
  <version>${maven-jar-plugin.version}</version>
  <configuration>
    <classifier>${git.branch.classifier}</classifier>
  </configuration>
</plugin>
```
