### PR TITLE
Added property 'git.commit.id.short-describe'

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -66,6 +66,7 @@ public class GitCommitIdMojo extends AbstractMojo {
   public static final String COMMIT_ID = "commit.id";
   public static final String COMMIT_ID_ABBREV = "commit.id.abbrev";
   public static final String COMMIT_DESCRIBE = "commit.id.describe";
+  public static final String COMMIT_SHORT_DESCRIBE = "commit.id.short-describe";
   public static final String BUILD_AUTHOR_NAME = "build.user.name";
   public static final String BUILD_AUTHOR_EMAIL = "build.user.email";
   public static final String BUILD_TIME = "build.time";
@@ -205,7 +206,7 @@ public class GitCommitIdMojo extends AbstractMojo {
    */
   @SuppressWarnings("UnusedDeclaration")
   private String prefix;
-  private String prefixDot;
+  private String prefixDot = "";
 
   /**
    * The date format to be used for any dates exported by this plugin.
@@ -308,6 +309,7 @@ public class GitCommitIdMojo extends AbstractMojo {
 
       loadGitData(properties);
       loadBuildTimeData(properties);
+      loadShortDescribe(properties);
       filterNot(properties, excludeProperties);
       logProperties(properties);
 
@@ -418,6 +420,27 @@ public class GitCommitIdMojo extends AbstractMojo {
     Date commitDate = new Date();
     SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
     put(properties, BUILD_TIME, smf.format(commitDate));
+  }
+  
+  void loadShortDescribe(@NotNull Properties properties) {
+    //removes git hash part from describe
+    String commitDescribe = properties.getProperty(prefixDot + COMMIT_DESCRIBE);
+
+    if (commitDescribe != null) {
+      int startPos = commitDescribe.indexOf("-g");
+      if (startPos > 0) {
+        String commitShortDescribe;
+        int endPos = commitDescribe.indexOf('-', startPos + 1);
+        if (endPos < 0) {
+          commitShortDescribe = commitDescribe.substring(0, startPos);
+        } else {
+          commitShortDescribe = commitDescribe.substring(0, startPos) + commitDescribe.substring(endPos);
+        }
+        put(properties, COMMIT_SHORT_DESCRIBE, commitShortDescribe);
+      } else {
+        put(properties, COMMIT_SHORT_DESCRIBE, commitDescribe);
+      }
+    }
   }
 
   void loadGitData(@NotNull Properties properties) throws IOException, MojoExecutionException {

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -272,6 +272,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     // then
     assertThat(targetProject.getProperties()).includes(entry("git.commit.id.describe", "v1.0.0"));
+    assertThat(targetProject.getProperties()).includes(entry("git.commit.id.short-describe", "v1.0.0"));
   }
 
   @Test
@@ -296,8 +297,9 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     // then
     assertThat(targetProject.getProperties()).includes(entry("git.commit.id.describe", "v1.0.0-0-gde4db35"));
+    assertThat(targetProject.getProperties()).includes(entry("git.commit.id.short-describe", "v1.0.0-0"));
   }
-
+  
   private void alterMojoSettings(String parameterName, Object parameterValue) {
     setInternalState(mojo, parameterName, parameterValue);
   }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -180,4 +180,26 @@ public class GitCommitIdMojoTest {
     env.put("GIT_BRANCH", "mybranch");
     assertThat(detachedHeadSHA1).isEqualTo(mojo.determineBranchName(git, env));
   }
+  
+  @Test
+  public void loadShortDescribe() {
+    assertShortDescribe("1.0.2-12-g19471", "1.0.2-12");
+    assertShortDescribe("1.0.2-12-g19471-DEV", "1.0.2-12-DEV");
+    assertShortDescribe("V-1.0.2-12-g19471-DEV", "V-1.0.2-12-DEV");
+
+    assertShortDescribe(null, null);
+    assertShortDescribe("12.4.0-1432", "12.4.0-1432");
+    assertShortDescribe("12.6.0", "12.6.0");
+    assertShortDescribe("", "");
+  }
+
+  private void assertShortDescribe(String commitDescribe, String expectedShortDescribe) {
+    GitCommitIdMojo commitIdMojo = new GitCommitIdMojo();
+    Properties prop = new Properties();
+    if (commitDescribe != null) {
+      prop.put(GitCommitIdMojo.COMMIT_DESCRIBE, commitDescribe);
+    }
+    commitIdMojo.loadShortDescribe(prop);
+    assertThat(prop.getProperty(GitCommitIdMojo.COMMIT_SHORT_DESCRIBE)).isEqualTo(expectedShortDescribe);
+  }
 }


### PR DESCRIPTION
Added property **git.commit.id.short-describe** that strips out commit hash and gives more (non-tech-) user friendly build number. 
For example, instead of _1.2.0-123-gd3a890_ it will give _1.2.0-123_.
