### PR TITLE
Search parent directories for .git dir

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -77,6 +77,25 @@ public class GitDirLocator {
    */
   @Nullable
   private File findProjectGitDirectory() {
+
+    try {
+      // First, search up the file system hierarchy, then the project hierarchy...
+      File baseDir = this.mavenProject.getBasedir().getCanonicalFile();
+
+      while(baseDir != null) {
+        File gitDir = new File(baseDir, Constants.DOT_GIT);
+
+        if (isExistingDirectory(gitDir)) {
+          return gitDir;
+        }
+
+        baseDir = baseDir.getParentFile();
+      }
+    } catch(IOException e) {
+      e.printStackTrace();
+      // pass
+    }
+
     MavenProject currentProject = this.mavenProject;
 
     while (currentProject != null) {

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -18,9 +18,13 @@
 package pl.project13.maven.git;
 
 import com.google.common.base.Optional;
+import com.google.common.io.Files;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.jgit.api.Git;
 import org.jetbrains.annotations.NotNull;
+import org.junit.After;
 import org.junit.Before;
 
 import java.io.File;
@@ -32,7 +36,7 @@ import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public abstract class GitIntegrationTest {
 
-  final String SANDBOX_DIR = "target/sandbox";
+  final String SANDBOX_DIR = Files.createTempDir().getAbsolutePath();
 
   protected GitCommitIdMojo mojo;
   protected FileSystemMavenSandbox mavenSandbox;
@@ -42,6 +46,11 @@ public abstract class GitIntegrationTest {
     mavenSandbox = new FileSystemMavenSandbox(SANDBOX_DIR);
     mojo = new GitCommitIdMojo();
     initializeMojoWithDefaults(mojo);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    FileUtils.deleteDirectory(new File(SANDBOX_DIR));
   }
 
   protected Git git() throws IOException, InterruptedException {


### PR DESCRIPTION
I ran into the issue described in ktoso/maven-git-commit-id-plugin#113 today. While I like the rev-parse idea and have seen that implemented in other places, I just opted to search parent directories until I find a .git directory within one.

To keep the tests passing, I had to modify them to use a different sandbox directory--one not parented by the project, otherwise the recursive parent calls would pick up the maven-git-command-id-plugin's git directory mistakenly.

This is working great for me now, but I welcome feedback.
