### PR TITLE
Improve gitdir handling with submodules

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -17,8 +17,6 @@
 
 package pl.project13.maven.git;
 
-import com.google.common.base.Optional;
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.jgit.lib.Constants;
 import org.jetbrains.annotations.NotNull;
@@ -43,7 +41,6 @@ public class GitDirLocator {
 
   @Nullable
   public File lookupGitDirectory(@NotNull File manuallyConfiguredDir) {
-
     if (manuallyConfiguredDir.exists()) {
 
       // If manuallyConfiguredDir is a directory then we can use it as the git path.
@@ -77,60 +74,25 @@ public class GitDirLocator {
    */
   @Nullable
   private File findProjectGitDirectory() {
-    MavenProject currentProject = this.mavenProject;
-
-    while (currentProject != null) {
-      File dir = getProjectGitDir(currentProject);
-
-      if (isExistingDirectory(dir)) {
-        return dir;
-      }
-      // If the path exists but is not a directory it might be a git submodule "gitdir" link.
-      File gitDirLinkPath = processGitDirFile(dir);
-
-      // If the linkPath was found from the file and it exists then use it.
-      if (isExistingDirectory(gitDirLinkPath)) {
-        return gitDirLinkPath;
-      }
-
-      /**
-       * project.getParent always returns NULL for me, but if getParentArtifact returns
-       * not null then there is actually a parent - seems like a bug in maven to me.
-       */
-      if (currentProject.getParent() == null && currentProject.getParentArtifact() != null) {
-        Optional<MavenProject> maybeFoundParentProject = getReactorParentProject(currentProject);
-
-        if (maybeFoundParentProject.isPresent())
-        currentProject = maybeFoundParentProject.get();
-
-      } else {
-        // Get the parent, or NULL if no parent AND no parentArtifact.
-        currentProject = currentProject.getParent();
-      }
+    if (this.mavenProject == null) {
+      return null;
     }
 
-    return null;
-  }
-
-  /**
-   * Find a project in the reactor by its artifact, I'm new to maven coding
-   * so there may be a better way to do this, it would not be necessary
-   * if project.getParent() actually worked.
-   *
-   * @return MavenProject parent project or NULL if no parent available
-   */
-  private Optional<MavenProject> getReactorParentProject(@NotNull MavenProject project) {
-    Artifact parentArtifact = project.getParentArtifact();
-
-    if (parentArtifact != null) {
-      for (MavenProject reactorProject : this.reactorProjects) {
-        if (reactorProject.getArtifactId().equals(parentArtifact.getArtifactId())) {
-          return Optional.of(reactorProject);
+    File basedir = mavenProject.getBasedir();
+    while (basedir != null) {
+      File gitdir = new File(basedir, Constants.DOT_GIT);
+      if (gitdir != null && gitdir.exists()) {
+        if (gitdir.isDirectory()) {
+          return gitdir;
+        } else if (gitdir.isFile()) {
+          return processGitDirFile(gitdir);
+        } else {
+          return null;
         }
       }
+      basedir = basedir.getParentFile();
     }
-
-    return Optional.absent();
+    return null;
   }
 
   /**
@@ -176,12 +138,6 @@ public class GitDirLocator {
     } catch (IOException e) {
       return null;
     }
-  }
-
-  @NotNull
-  private static File getProjectGitDir(@NotNull MavenProject mavenProject) {
-    // FIXME Shouldn't this look at the dotGitDirectory property (if set) for the given project?
-    return new File(mavenProject.getBasedir(), Constants.DOT_GIT);
   }
 
   private static boolean isExistingDirectory(@Nullable File fileLocation) {

--- a/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
@@ -42,14 +42,18 @@ public class GitDirLocatorTest {
   public void shouldUseTheManuallySpecifiedDirectory() throws Exception {
     // given
     File dotGitDir = Files.createTempDir();
+    try {
 
-    // when
-    GitDirLocator locator = new GitDirLocator(project, reactorProjects);
-    File foundDirectory = locator.lookupGitDirectory(dotGitDir);
+      // when
+      GitDirLocator locator = new GitDirLocator(project, reactorProjects);
+      File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
-    // then
-    assert foundDirectory != null;
-    assertThat(foundDirectory.getAbsolutePath()).isEqualTo(dotGitDir.getAbsolutePath());
+      // then
+      assert foundDirectory != null;
+      assertThat(foundDirectory.getAbsolutePath()).isEqualTo(dotGitDir.getAbsolutePath());
+    } finally {
+      dotGitDir.delete();
+    }
   }
 
 }


### PR DESCRIPTION
Thanks for the plugin! 

This pull req fixes two issues I encountered:
- When using git submodules some older git version (e.g., 1.7.9, used by Ubuntu 12.04 LTS) use absolute path in the .git gitdir reference. I've added support for absolute path.
- When searching for the gitdir the plugin should search the parent _directory_ not the parent project. Esp. with submodules searching the parent project is not correct since the parent might be in a different git repo. 
