### PR TITLE
Slightly improved exception handling for wrong dotGitDirectory.

### DIFF
--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -106,6 +106,8 @@ public class JGitProvider extends GitDataProvider {
       revWalk = new RevWalk(git);
       headCommit = revWalk.parseCommit(HEAD.getObjectId());
       revWalk.markStart(headCommit);
+    } catch (MojoExecutionException e) {
+      throw e;
     } catch (Exception e) {
       throw new MojoExecutionException("Error", e);
     }


### PR DESCRIPTION
Hello Konrad,

To make stack trace as readable as possible when incorrect `dotGitDirectory` is passed I would add just one more simple improvement. I know it increases the code a little bit, but the result is

```
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building rest-showcase 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- git-commit-id-plugin:2.1.16-SNAPSHOT:revision (default) @ rest-showcase ---
[info] dotGitDirectory C:\Work\Projects\rest-showcase\src
[info] git.build.user.name Tomasz Przybyla
[info] git.build.user.email bsodzik@tlen.pl
org.apache.maven.plugin.MojoExecutionException: Could not get HEAD Ref, are you sure you've set the dotGitDirectory property of this plugin to a valid path?
    at pl.project13.maven.git.JGitProvider.prepareGitToExtractMoreDetailedReproInformation(JGitProvider.java:104)
    at pl.project13.maven.git.GitDataProvider.loadGitData(GitDataProvider.java:57)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitDataWithJGit(GitCommitIdMojo.java:485)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitData(GitCommitIdMojo.java:457)
    at pl.project13.maven.git.GitCommitIdMojo.execute(GitCommitIdMojo.java:315)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:106)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:317)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:152)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
    at org.codehaus.classworlds.Launcher.main(Launcher.java:46)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.995s
[INFO] Finished at: Fri Nov 28 08:22:02 CET 2014
[INFO] Final Memory: 12M/176M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.1.16-SNAPSHOT:revision (default) on project rest-showcase: Could not complete Mojo execution... Could not get HEAD Ref, are you sure you've set the dotGitDirectory property of this plugin to a valid path? -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

You are the boss here, yours is the decision :)
BTW. Thanks for great plugin - with Spring Boot it works like a charm!
