### PR TITLE
Fix for https://github.com/ktoso/maven-git-commit-id-plugin/issues/146

### DIFF
--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -73,9 +73,15 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   private String getBranch(File canonical) {
-    String branch = tryToRunGitCommand(canonical, "symbolic-ref HEAD");
-    if (branch != null) {
-      branch = branch.replace("refs/heads/", "");
+    String branch = null;
+    try{
+      branch = tryToRunGitCommand(canonical, "symbolic-ref HEAD");
+      if (branch != null) {
+        branch = branch.replace("refs/heads/", "");
+      }
+    }catch(RuntimeException e){
+      // it seems that git repro is in 'DETACHED HEAD'-State, using Commid-Id as Branch
+      branch = getCommitId();
     }
     return branch;
   }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -621,11 +621,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Test
   @Parameters(method = "useNativeGit")
   public void runGitDescribeWithMatchOption(boolean useNativeGit) throws Exception {
-    if (System.getenv().get("TRAVIS").equals("true") && System.getenv().get("CI").equals("true")) {
-      // FIXME: this test has trouble on travis, I think it's because of not pulling everything?
-      return;
-    }
-
     // given
     mavenSandbox.withParentProject("my-pom-project", "pom")
                 .withChildProject("my-jar-module", "jar")


### PR DESCRIPTION
@ktoso ,
Well I think this tiny bit of code-change already fixes #146.
In case of detached HEAD-State the JGit-Implementation uses the SHA of the commit. With this PR the same behavoir is implemented for the Native Git-Implementation.

Considered following:
1) Even if the the general Execution-Error (git-Binary couldn't be found), this error will be triggered by the "getCommitId"-Call. 
2) In Terms of Performance we could swap "determineBranchName" and "getCommitId" in the GitDataProvider. When the "getCommitId" will be triggered before the "determineBranchName" we could save the SHA of the current commit inside the Native-Git-Implementation instead of just asking again.

Additional comments are welcome...
