### PR TITLE
use openjdk10, add maven 3.6.0 to integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
     env: CUSTOM_MVN_VERION="3.5.0"
   - jdk: oraclejdk9
     env: CUSTOM_MVN_VERION="3.5.4"
+  - jdk: oraclejdk9
+    env: CUSTOM_MVN_VERION="3.6.0"
   - stage: checkstyle
     jdk: oraclejdk9
     script: mvn clean verify -Pcheckstyle -Dcheckstyle.version=8.2 -Dmaven.test.skip=true -B


### PR DESCRIPTION
### Context
- oraclejdk10 is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using openjdk10 instead -- see also https://travis-ci.community/t/help-with-oraclejdk10-build-on-linux/398/8
- add maven 3.6.0 to the list of integration tests