### PR TITLE
[tests] Migrate off fest-assert to assertj

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -35,7 +35,7 @@
     <junit.version>4.13.1</junit.version>
     <mockito.version>3.1.0</mockito.version>
 
-    <fest-assert.version>1.4</fest-assert.version>
+    <assertj.version>3.14.0</assertj.version>
   </properties>
 
   <dependencies>
@@ -78,9 +78,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
-      <version>${fest-assert.version}</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/maven/src/test/java/pl/project13/core/GitDataProviderTest.java
+++ b/maven/src/test/java/pl/project13/core/GitDataProviderTest.java
@@ -22,7 +22,7 @@ import pl.project13.core.log.LoggerBridge;
 
 import java.util.Properties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 

--- a/maven/src/test/java/pl/project13/core/jgit/DescribeCommandAbbrevIntegrationTest.java
+++ b/maven/src/test/java/pl/project13/core/jgit/DescribeCommandAbbrevIntegrationTest.java
@@ -27,7 +27,7 @@ import pl.project13.maven.git.GitIntegrationTest;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DescribeCommandAbbrevIntegrationTest extends GitIntegrationTest {
 

--- a/maven/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
+++ b/maven/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;

--- a/maven/src/test/java/pl/project13/core/jgit/DescribeCommandTagsIntegrationTest.java
+++ b/maven/src/test/java/pl/project13/core/jgit/DescribeCommandTagsIntegrationTest.java
@@ -28,7 +28,7 @@ import pl.project13.maven.git.GitIntegrationTest;
 
 import java.util.Optional;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
 

--- a/maven/src/test/java/pl/project13/core/jgit/DescribeResultTest.java
+++ b/maven/src/test/java/pl/project13/core/jgit/DescribeResultTest.java
@@ -28,7 +28,7 @@ import pl.project13.maven.git.GitIntegrationTest;
 
 import java.util.Optional;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DescribeResultTest extends GitIntegrationTest {
 

--- a/maven/src/test/java/pl/project13/core/jgit/JGitCommonIntegrationTest.java
+++ b/maven/src/test/java/pl/project13/core/jgit/JGitCommonIntegrationTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import pl.project13.core.log.StdOutLoggerBridge;
 import pl.project13.maven.git.GitIntegrationTest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitCommonIntegrationTest extends GitIntegrationTest {
 

--- a/maven/src/test/java/pl/project13/maven/git/BigDiffTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/BigDiffTest.java
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Run this to simulate hanging native-git-process for repo-state with lots of changes.

--- a/maven/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
+++ b/maven/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
@@ -17,7 +17,7 @@
 
 package pl.project13.maven.git;
 
-import org.fest.assertions.Condition;
+import org.assertj.core.api.Condition;
 
 import javax.annotation.Nonnull;
 import java.util.Map;

--- a/maven/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
+++ b/maven/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
@@ -17,7 +17,7 @@
 
 package pl.project13.maven.git;
 
-import org.fest.assertions.Condition;
+import org.assertj.core.api.Condition;
 
 import javax.annotation.Nonnull;
 import java.util.Map;

--- a/maven/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -38,8 +38,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static java.util.Arrays.*;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 @RunWith(JUnitParamsRunner.class)
 public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
@@ -750,7 +750,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     mojo.execute();
 
     // then
-    assertThat(targetProject.getProperties()).includes(entry("git.commit.id.abbrev", "de4db35917"));
+    assertThat(targetProject.getProperties()).contains(entry("git.commit.id.abbrev", "de4db35917"));
   }
 
   @Test
@@ -776,8 +776,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
     String expectedDate = smf.format(new Date());
-    assertThat(targetProject.getProperties()).includes(entry("git.build.time", expectedDate));
-    assertThat(targetProject.getProperties()).includes(entry("git.commit.time", "08/19/2012"));
+    assertThat(targetProject.getProperties()).contains(entry("git.build.time", expectedDate));
+    assertThat(targetProject.getProperties()).contains(entry("git.commit.time", "08/19/2012"));
   }
 
   @Test
@@ -826,7 +826,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     mojo.execute();
 
     // then
-    assertThat(targetProject.getProperties()).includes(entry("git.commit.id.describe", "v1.0.0-0-gde4db35" + dirtySuffix));
+    assertThat(targetProject.getProperties()).contains(entry("git.commit.id.describe", "v1.0.0-0-gde4db35" + dirtySuffix));
   }
 
   @Test
@@ -1183,7 +1183,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     // then
     Properties properties = targetProject.getProperties();
     assertThat(properties.stringPropertyNames()).contains("git.commit.id");
-    assertThat(properties.stringPropertyNames()).excludes("git.commit.id.full");
+    assertThat(properties.stringPropertyNames()).doesNotContain("git.commit.id.full");
   }
 
   @Test
@@ -1212,7 +1212,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     // then
     Properties properties = targetProject.getProperties();
     assertThat(properties.get("git.dirty")).isEqualTo("false");
-    assertThat(properties).includes(entry("git.commit.id.describe", "85c2888")); // assert no dirtySuffix at the end!
+    assertThat(properties).contains(entry("git.commit.id.describe", "85c2888")); // assert no dirtySuffix at the end!
   }
 
   @Test
@@ -1241,7 +1241,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     // then
     Properties properties = targetProject.getProperties();
     assertThat(properties.get("git.dirty")).isEqualTo("true");
-    assertThat(properties).includes(entry("git.commit.id.describe", "0b0181b" + dirtySuffix)); // assert dirtySuffix at the end!
+    assertThat(properties).contains(entry("git.commit.id.describe", "0b0181b" + dirtySuffix)); // assert dirtySuffix at the end!
   }
 
   @Test

--- a/maven/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import java.util.regex.Pattern;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/maven/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GitDirLocatorTest {

--- a/maven/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import pl.project13.core.util.PropertyManager;
 
 import static java.util.Arrays.asList;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class GitPropertiesFileTest extends GitIntegrationTest {

--- a/maven/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Properties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitSubmodulesTest extends GitIntegrationTest {
 

--- a/maven/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class NaivePerformanceTest extends GitIntegrationTest {

--- a/maven/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -17,7 +17,7 @@
 
 package pl.project13.maven.git;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.text.DateFormat;


### PR DESCRIPTION
fest-assert 2 once was assertj.  The authors differed in direction and the framework split.  fest-assert itself is long dead.  Version 2 never made release as a result and the migration as it were is incredibly easy as seen here and at least in one test set makes more logical sense.
