### PR TITLE
Simplify GitHub workflow, cache local Maven repository

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -4,23 +4,26 @@ on: [push, pull_request]
 
 jobs:
   checkstyle:
-    name: Run checkstyle with java ${{ matrix.java_version }}
+    name: Run checkstyle
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        java_version: ['8']
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK ${{ matrix.java_version }}
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java_version }}
+          java-version: 8
+      - name: Cache local Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Run checkstyle with Maven
-        run: mvn --file pom.xml clean verify -Pcheckstyle -Dmaven.test.skip=true -B
+        run: mvn clean verify -B -Pcheckstyle -Dmaven.test.skip=true
 
   test:
-    name: Run basic test with java ${{ matrix.java_version }}
+    name: Run basic test with Java ${{ matrix.java_version }}
     runs-on: ubuntu-latest
     needs: checkstyle
     if: github.event_name == 'pull_request'
@@ -34,11 +37,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java_version }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn clean verify -B
 
   integration-test:
-    name: Run integration test with java ${{ matrix.java_version }} and Maven ${{ matrix.maven_version }}
+    name: Run integration test with Java ${{ matrix.java_version }} and Maven ${{ matrix.maven_version }}
     runs-on: ubuntu-latest
     needs: checkstyle
     if: github.event_name == 'pull_request'
@@ -55,7 +64,7 @@ jobs:
           java-version: ${{ matrix.java_version }}
       - name: Setup Maven ${{ matrix.maven_version }}
         run: /bin/bash -c 'if [[ -n "${{ matrix.maven_version }}" ]]; then \
-            echo "Download Maven ${{ matrix.maven_version }}....";
+            echo "Downloading Maven ${{ matrix.maven_version }}....";
             if [[ "${{ matrix.maven_version }}" == "3.0" ]]; then
               wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || terminate 1;
             else
@@ -66,12 +75,19 @@ jobs:
             export PATH=$M2_HOME/bin:$PATH;
             mvn -version;
           fi'
-      - name: Package with Maven
-        run: mvn clean package -B
+      - name: Cache local Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          # Include Maven version in key to not use cache from other Maven versions
+          # in case they corrupt the local repository
+          # Include it before `-m2-` to prevent other cache actions' restore-keys matching it
+          key: ${{ runner.os }}-maven-${{ matrix.maven_version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-${{ matrix.maven_version }}-m2
       - name: Install a test version with Maven
-        run: mvn clean test install -B
+        run: mvn clean install -B
       - name: Run the local testversion with Maven
-        run: mvn clean initialize -Pdemo -Dmaven.test.skip=true -B
+        run: mvn clean initialize -B -Pdemo -Dmaven.test.skip=true
       - name: Validate if the testversion has produced the desired output
         run: /bin/bash -c '[[ -f maven/target/testing.properties ]] && cat maven/target/testing.properties || exit 1;'
 
@@ -88,29 +104,36 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git checkout "${GITHUB_REF:11}"
-      - name: Set up JDK ${{ matrix.java_version }}
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java_version }}
-      - name: Run Coveralls with maven
-        run: mvn clean test jacoco:report coveralls:report -Pcoveralls -DrepoToken=${{ secrets.CoverallsRepoTokenSecret }} -B
+          java-version: 8
+      - name: Cache local Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Coveralls with Maven
+        run: mvn clean test jacoco:report coveralls:report -B -Pcoveralls -DrepoToken=${{ secrets.CoverallsRepoTokenSecret }}
 
   deploy-snapshot:
-    name: Run coveralls with java ${{ matrix.java_version }}
+    name: Deploy snapshot
     runs-on: ubuntu-latest
     needs: integration-test
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
 
-    strategy:
-      matrix:
-        java_version: ['8']
-
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK ${{ matrix.java_version }}
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java_version }}
-      - name: Deploy snapshot with maven
-        run: mvn clean deploy --settings=./.buildscript/settings.xml
-
+          java-version: 8
+      - name: Cache local Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Deploy snapshot with Maven
+        run: mvn clean deploy -B --settings=./.buildscript/settings.xml


### PR DESCRIPTION
### Context
Changes the GitHub workflow:
- Remove Java version matrix where it makes sense to only use one version, e.g. deploying snapshot
- Use consistent `mvn` command structure:
  - `-B` as first flag
  - `--file pom.xml` is redundant
- Remove "Package with Maven" step from `integration-test` because `clean install` should cover that already
- Use cache to not require GitHub to download Maven dependencies every time

Note that concurrent / parallel usage of the same cache might cause issues (see https://github.com/actions/cache/issues/189), however without it, a cache per job, per Java version / Maven version would be needed, for which the total cache size might become pretty large at some point.

You can see a successful run in my fork: https://github.com/Marcono1234/git-commit-id-maven-plugin/actions/runs/103612944