### PR TITLE
Remove unused Java version matrix from GitHub workflow

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -99,10 +99,6 @@ jobs:
     needs: integration-test
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
 
-    strategy:
-      matrix:
-        java_version: ['8']
-
     steps:
       - uses: actions/checkout@v1
       - run: git checkout "${GITHUB_REF:11}"


### PR DESCRIPTION
### Context
The Java version matrix is not used anymore because the Java version is specified explicitly. I forgot to remove that in #486.