### PR TITLE
Remove dependency on Google Guava

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,10 +21,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
         <!-- JGit -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -47,6 +43,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.9.10.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -17,8 +17,6 @@
 
 package pl.project13.core;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import pl.project13.core.git.GitDescribeConfig;
 import pl.project13.core.cibuild.BuildServerDataProvider;
 import pl.project13.core.cibuild.UnknownBuildServerData;
@@ -27,14 +25,11 @@ import pl.project13.core.util.PropertyManager;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.*;
 import java.text.SimpleDateFormat;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 public abstract class GitDataProvider implements GitProvider {
 
@@ -229,7 +224,7 @@ public abstract class GitDataProvider implements GitProvider {
     BuildServerDataProvider buildServerDataProvider = BuildServerDataProvider.getBuildServerProvider(env,log);
     if (useBranchNameFromBuildEnvironment && !(buildServerDataProvider instanceof UnknownBuildServerData)) {
       String branchName = buildServerDataProvider.getBuildBranch();
-      if (isNullOrEmpty(branchName)) {
+      if (branchName == null || branchName.isEmpty()) {
         log.info("Detected that running on CI environment, but using repository branch, no GIT_BRANCH detected.");
         return getBranchName();
       }
@@ -262,7 +257,6 @@ public abstract class GitDataProvider implements GitProvider {
 
   @FunctionalInterface
   public interface SupplierEx<T> {
-    @CanIgnoreReturnValue
     T get() throws GitCommitIdExecutionException;
   }
 

--- a/core/src/main/java/pl/project13/core/JGitProvider.java
+++ b/core/src/main/java/pl/project13/core/JGitProvider.java
@@ -17,8 +17,6 @@
 
 package pl.project13.core;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -285,7 +283,8 @@ public class JGitProvider extends GitDataProvider {
     }
   }
 
-  @VisibleForTesting String getGitDescribe(@Nonnull Repository repository) throws GitCommitIdExecutionException {
+  // Visible for testing
+  String getGitDescribe(@Nonnull Repository repository) throws GitCommitIdExecutionException {
     try {
       DescribeResult describeResult = DescribeCommand
           .on(evaluateOnCommit, repository, log)
@@ -356,7 +355,6 @@ public class JGitProvider extends GitDataProvider {
 
   // SETTERS FOR TESTS ----------------------------------------------------
 
-  @VisibleForTesting
   public void setRepository(Repository git) {
     this.git = git;
   }

--- a/core/src/main/java/pl/project13/core/NativeGitProvider.java
+++ b/core/src/main/java/pl/project13/core/NativeGitProvider.java
@@ -24,8 +24,6 @@ import pl.project13.core.log.LoggerBridge;
 
 import javax.annotation.Nonnull;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -586,8 +584,8 @@ public class NativeGitProvider extends GitDataProvider {
       log.error("Failed to execute fetch", e);
     }
   }
-  
-  @VisibleForTesting
+
+  // Visible for testing
   public void setEvaluateOnCommit(String evaluateOnCommit) {
     this.evaluateOnCommit = evaluateOnCommit;
   }

--- a/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
+++ b/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
@@ -19,16 +19,14 @@ package pl.project13.core;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Files;
 import org.sonatype.plexus.build.incremental.BuildContext;
-import pl.project13.core.GitCommitIdExecutionException;
-import pl.project13.core.GitCommitPropertyConstant;
 import pl.project13.core.log.LoggerBridge;
 import pl.project13.core.util.SortedProperties;
 
 import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -86,7 +84,7 @@ public class PropertiesFileGenerator {
       }
 
       if (shouldGenerate) {
-        Files.createParentDirs(gitPropsFile);
+        Files.createDirectories(gitPropsFile.getParentFile().toPath());
         try (OutputStream outputStream = new FileOutputStream(gitPropsFile)) {
           SortedProperties sortedLocalProperties = new SortedProperties();
           sortedLocalProperties.putAll(localProperties);

--- a/core/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
@@ -23,8 +23,6 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Properties;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 public class GitHubBuildServerData extends BuildServerDataProvider {
 
   private static final String BRANCH_REF_PREFIX = "refs/heads/";
@@ -49,7 +47,7 @@ public class GitHubBuildServerData extends BuildServerDataProvider {
   @Override
   public String getBuildBranch() {
     String gitHubRef = env.get("GITHUB_REF");
-    if (!isNullOrEmpty(gitHubRef)) {
+    if (gitHubRef != null && !gitHubRef.isEmpty()) {
       if (gitHubRef.startsWith(BRANCH_REF_PREFIX)) {
         String branchName = gitHubRef.substring(BRANCH_REF_PREFIX.length());
         log.info("Using environment variable based branch name. GITHUB_REF = {} (branch = {})", gitHubRef, branchName);

--- a/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
@@ -24,8 +24,6 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Properties;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 public class HudsonJenkinsBuildServerData extends BuildServerDataProvider {
 
   HudsonJenkinsBuildServerData(@Nonnull LoggerBridge log, @Nonnull Map<String, String> env) {
@@ -50,7 +48,7 @@ public class HudsonJenkinsBuildServerData extends BuildServerDataProvider {
   @Override
   public String getBuildBranch() {
     String environmentBasedLocalBranch = env.get("GIT_LOCAL_BRANCH");
-    if (!isNullOrEmpty(environmentBasedLocalBranch)) {
+    if (environmentBasedLocalBranch != null && !environmentBasedLocalBranch.isEmpty()) {
       log.info("Using environment variable based branch name. GIT_LOCAL_BRANCH = {}",
           environmentBasedLocalBranch);
       return environmentBasedLocalBranch;

--- a/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
+++ b/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
@@ -17,9 +17,6 @@
 
 package pl.project13.core.jgit;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
@@ -144,8 +141,12 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   @Nonnull
   public DescribeCommand abbrev(@Nullable Integer n) {
     if (n != null) {
-      Preconditions.checkArgument(n < 41, String.format("N (commit abbrev length) must be < 41. (Was:[%s])", n));
-      Preconditions.checkArgument(n >= 0, String.format("N (commit abbrev length) must be positive! (Was [%s])", n));
+      if (n >= 41) {
+        throw new IllegalArgumentException("N (commit abbrev length) must be < 41. (Was:[" + n + "])");
+      }
+      if (n < 0) {
+        throw new IllegalArgumentException("N (commit abbrev length) must be positive! (Was [" + n + "])");
+      }
       log.info("--abbrev = {}", n);
       abbrev = n;
     }
@@ -332,12 +333,12 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     return tags.isEmpty();
   }
 
-  @VisibleForTesting
+  // Visible for testing
   boolean findDirtyState(Repository repo) throws GitAPIException {
     return JGitCommon.isRepositoryInDirtyState(repo);
   }
 
-  @VisibleForTesting
+  // Visible for testing
   static boolean hasTags(ObjectId headCommit, @Nonnull Map<ObjectId, List<String>> tagObjectIdToName) {
     return tagObjectIdToName.containsKey(headCommit);
   }

--- a/core/src/main/java/pl/project13/core/jgit/DescribeResult.java
+++ b/core/src/main/java/pl/project13/core/jgit/DescribeResult.java
@@ -17,7 +17,6 @@
 
 package pl.project13.core.jgit;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.*;
 
@@ -96,7 +95,9 @@ public class DescribeResult {
 
   @Nonnull
   public DescribeResult withCommitIdAbbrev(int n) {
-    Preconditions.checkArgument(n >= 0, String.format("The --abbrev parameter must be >= 0, but it was: [%s]", n));
+    if (n < 0) {
+      throw new IllegalArgumentException("The --abbrev parameter must be >= 0, but it was: [" + n + "]");
+    }
     this.abbrev = n;
     this.abbreviatedObjectId = createAbbreviatedCommitId(this.objectReader, this.commitId.get(), this.abbrev);
     return this;

--- a/core/src/main/java/pl/project13/core/jgit/JGitCommon.java
+++ b/core/src/main/java/pl/project13/core/jgit/JGitCommon.java
@@ -35,7 +35,6 @@ import org.eclipse.jgit.revwalk.RevWalk;
 
 import pl.project13.core.jgit.dummy.DatedRevTag;
 
-import com.google.common.annotations.VisibleForTesting;
 import pl.project13.core.git.GitDescribeConfig;
 import pl.project13.core.log.LoggerBridge;
 import pl.project13.core.util.Pair;
@@ -238,7 +237,7 @@ public class JGitCommon {
     return (revTag, revTag2) -> revTag2.date.compareTo(revTag.date);
   }
 
-  @VisibleForTesting
+  // Visible for testing
   protected String trimFullTagName(@Nonnull String tagName) {
     return tagName.replaceFirst("refs/tags/", "");
   }

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -56,18 +56,17 @@
       <artifactId>git-commit-id-plugin-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven-plugin-plugin.version}</version>
       <scope>provided</scope><!-- annotations are needed only to build the plugin -->
-    </dependency>
-
-    <!-- Guava -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
 
     <!-- Test stuff -->

--- a/maven/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/maven/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -17,7 +17,6 @@
 
 package pl.project13.maven.git;
 
-import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.project.MavenProject;
 
@@ -25,6 +24,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Quick and dirty maven projects tree structure to create on disk during integration tests.
@@ -121,8 +121,8 @@ public class FileSystemMavenSandbox {
       // folders whose existence is crucial for the native git to run (jgit does not mind)
       // *and* because empty folders are silently omitted from git checkins, ensure that
       // these folders exist
-      Files.createParentDirs(new File(gitFolder, "refs/heads"));
-      Files.createParentDirs(new File(gitFolder, "refs/tags"));
+      Files.createDirectories(new File(gitFolder, "refs/heads").toPath());
+      Files.createDirectories(new File(gitFolder, "refs/tags").toPath());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,10 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>28.0-jre</version>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Context

While Google Guava provides a lot of useful functionality, it is a rather heavy-weight dependency and was notorious for breaking backward-compatibility in the past.

There are only very few features from Google Guava used in `git-commit-id-maven-plugin` which could either be replaced by native Java 8 features (`Files.createParentDirs()`) or removed altogether (`@VisibleForTesting`).

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
