### PR TITLE
Address Mockito deprecation warnings

### DIFF
--- a/maven/src/test/java/pl/project13/maven/git/PropertiesFiltererTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/PropertiesFiltererTest.java
@@ -57,7 +57,7 @@ public class PropertiesFiltererTest {
 
     propertiesFilterer.filterNot(properties, exclusions, PREFIX_DOT);
 
-    Mockito.verifyZeroInteractions(properties);
+    Mockito.verifyNoInteractions(properties);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class PropertiesFiltererTest {
 
     propertiesFilterer.filterNot(properties, exclusions, PREFIX_DOT);
 
-    Mockito.verifyZeroInteractions(properties);
+    Mockito.verifyNoInteractions(properties);
   }
 
   @Test
@@ -88,7 +88,7 @@ public class PropertiesFiltererTest {
 
     propertiesFilterer.filter(properties, inclusions, PREFIX_DOT);
 
-    Mockito.verifyZeroInteractions(properties);
+    Mockito.verifyNoInteractions(properties);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class PropertiesFiltererTest {
 
     propertiesFilterer.filter(properties, inclusions, PREFIX_DOT);
 
-    Mockito.verifyZeroInteractions(properties);
+    Mockito.verifyNoInteractions(properties);
   }
 
   @Test


### PR DESCRIPTION
### Context

`Mockito.verifyZeroInteractions()` has been deprecated in favor of `Mockito.verifyNoInteractions()`.

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
