### PR TITLE
Depend on JUnit 4.12 instead of JUnit 5.5.1

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -32,7 +32,7 @@
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-    <junit.version>5.5.1</junit.version>
+    <junit.version>4.12</junit.version>
     <mockito.version>3.1.0</mockito.version>
 
     <fest-assert.version>1.4</fest-assert.version>
@@ -72,8 +72,8 @@
 
     <!-- Test stuff -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
### Context

While JUnit 5.5.1 (API) is being declared as a dependency, the actual tests are all using JUnit 4.x.

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
