### PR TITLE
Add support for AWS CodeBuild

### DIFF
--- a/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.core.cibuild;
+
+import pl.project13.core.GitCommitPropertyConstant;
+import pl.project13.core.log.LoggerBridge;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Properties;
+
+public class AwsCodeBuildBuildServerData extends BuildServerDataProvider {
+
+  AwsCodeBuildBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
+    super(log,env);
+  }
+
+  /**
+   * @see <a href="https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html">Environment variables in build environments</a>
+   */
+  public static boolean isActiveServer(Map<String, String> env) {
+    return env.containsKey("CODEBUILD_BUILD_ARN");
+  }
+
+  @Override
+  void loadBuildNumber(@Nonnull Properties properties) {
+    String buildNumber = env.getOrDefault("CODEBUILD_BUILD_NUMBER", "");
+    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+
+    String buildArn = env.get("CODEBUILD_BUILD_ARN");
+    put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, buildArn);
+  }
+
+  @Override
+  public String getBuildBranch() {
+    String environmentBasedBranch = env.getOrDefault("CODEBUILD_SOURCE_VERSION", "");
+    log.info("Using environment variable based branch name. CODEBUILD_SOURCE_VERSION = {}", environmentBasedBranch);
+    return environmentBasedBranch;
+  }
+}

--- a/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
@@ -42,7 +42,7 @@ public class AwsCodeBuildBuildServerData extends BuildServerDataProvider {
     String buildNumber = env.getOrDefault("CODEBUILD_BUILD_NUMBER", "");
     put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
 
-    String buildArn = env.get("CODEBUILD_BUILD_ARN");
+    String buildArn = env.get("CODEBUILD_BUILD_ID");
     put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, buildArn);
   }
 

--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -106,6 +106,9 @@ public abstract class BuildServerDataProvider {
     if (GitHubBuildServerData.isActiveServer(env)) {
       return new GitHubBuildServerData(log, env);
     }
+    if (AwsCodeBuildBuildServerData.isActiveServer(env)) {
+      return new AwsCodeBuildBuildServerData(log, env);
+    }
     return new UnknownBuildServerData(log, env);
   }
 

--- a/maven/docs/using-the-plugin.md
+++ b/maven/docs/using-the-plugin.md
@@ -914,6 +914,6 @@ Refer to the table below to see which values are supported by which CIs.
  
  | variable                  | description                             | supported CIs                                             |    
  | ------------------------- | ----------------------------------------|:---------------------------------------------------------:|   
- |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5), Azure DevOps|        
- |`git.build.number.unique`  | holds a system wide unique build number | TeamCity, Travis, Gitlab CI (Gitlab >11.0)                          |
+ |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5), Azure DevOps, AWS CodeBuild |        
+ |`git.build.number.unique`  | holds a system wide unique build number | TeamCity, Travis, Gitlab CI (Gitlab >11.0), AWS CodeBuild |
 


### PR DESCRIPTION
### Context

Add support for fetching build information on [AWS CodeBuild](https://aws.amazon.com/codebuild/).

The available environment variables in the AWS CodeBuild build environment are listed at [Environment variables in build environments](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html).

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
