### PR TITLE
Upgrade to Jackson 2.11.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
+++ b/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
@@ -18,6 +18,7 @@
 package pl.project13.core;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.sonatype.plexus.build.incremental.BuildContext;
 import pl.project13.core.log.LoggerBridge;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class PropertiesFileGenerator {
+  private static final ObjectMapper MAPPER = new ObjectMapper().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES);
 
   private LoggerBridge log;
   private BuildContext buildContext;
@@ -91,8 +93,7 @@ public class PropertiesFileGenerator {
           if (isJsonFormat) {
             try (Writer outputWriter = new OutputStreamWriter(outputStream, sourceCharset)) {
               log.info("Writing json file to [{}] (for module {})...", gitPropsFile.getAbsolutePath(), projectName);
-              ObjectMapper mapper = new ObjectMapper();
-              mapper.writerWithDefaultPrettyPrinter().writeValue(outputWriter, sortedLocalProperties);
+              MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputWriter, sortedLocalProperties);
             }
           } else {
             log.info("Writing properties file to [{}] (for module {})...", gitPropsFile.getAbsolutePath(), projectName);
@@ -131,11 +132,10 @@ public class PropertiesFileGenerator {
 
     try (final FileInputStream fis = new FileInputStream(jsonFile)) {
       try (final InputStreamReader reader = new InputStreamReader(fis, sourceCharset)) {
-        final ObjectMapper mapper = new ObjectMapper();
         final TypeReference<HashMap<String, Object>> mapTypeRef =
                 new TypeReference<HashMap<String, Object>>() {};
 
-        propertiesMap = mapper.readValue(reader, mapTypeRef);
+        propertiesMap = MAPPER.readValue(reader, mapTypeRef);
       }
     } catch (final Exception ex) {
       throw new CannotReadFileException(ex);


### PR DESCRIPTION
### Context

Jackson 2.9.x had and still gets a lot of CVEs because of how it handles deserialization of polymorphic types.

This has been fixed in Jackson 2.10.x and 2.11.x, so upgrading will safe this project from (unnecessary) security alerts.

* https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
* https://medium.com/@cowtowncoder/jackson-2-10-safe-default-typing-2d018f0ce2ba

Additionally, explicitly block unsafe polymorphic base types with Jackson, just in case. 😉 

Refs #489
Closes #500
Refs #501

### Contributor Checklist
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
