### PR TITLE
Build system information should be optionally set

### DIFF
--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -245,7 +245,7 @@ public abstract class GitDataProvider implements GitProvider {
   protected void maybePut(@Nonnull Properties properties, String key, SupplierEx<String> value)
           throws GitCommitIdExecutionException {
     String keyWithPrefix = prefixDot + key;
-    if (properties.containsKey(keyWithPrefix)) {
+    if (properties.stringPropertyNames().contains(keyWithPrefix)) {
       String propertyValue = properties.getProperty(keyWithPrefix);
       log.info("Using cached {} with value {}", keyWithPrefix, propertyValue);
     } else if (PropertiesFilterer.isIncluded(keyWithPrefix, includeOnlyProperties, excludeProperties)) {

--- a/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
+++ b/core/src/main/java/pl/project13/core/PropertiesFileGenerator.java
@@ -75,8 +75,8 @@ public class PropertiesFileGenerator {
 
           final String buildTimeProperty = prefixDot + GitCommitPropertyConstant.BUILD_TIME;
 
-          propertiesCopy.remove(buildTimeProperty);
-          persistedProperties.remove(buildTimeProperty);
+          propertiesCopy.setProperty(buildTimeProperty, null);
+          persistedProperties.setProperty(buildTimeProperty, null);
 
           shouldGenerate = !propertiesCopy.equals(persistedProperties);
         } catch (CannotReadFileException ex) {

--- a/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
@@ -40,10 +40,10 @@ public class AwsCodeBuildBuildServerData extends BuildServerDataProvider {
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
     String buildNumber = env.getOrDefault("CODEBUILD_BUILD_NUMBER", "");
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
 
     String buildArn = env.get("CODEBUILD_BUILD_ID");
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, buildArn);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, () -> buildArn);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/AzureDevOpsBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AzureDevOpsBuildServerData.java
@@ -41,7 +41,7 @@ public class AzureDevOpsBuildServerData extends BuildServerDataProvider {
   void loadBuildNumber(@Nonnull Properties properties) {
     String buildNumber = env.getOrDefault("BUILD_BUILDNUMBER", "");
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
@@ -40,7 +40,7 @@ public class BambooBuildServerData extends BuildServerDataProvider {
     String buildNumber = Optional.ofNullable(env.get("bamboo.buildNumber"))
             .orElseGet(() -> env.getOrDefault("BAMBOO_BUILDNUMBER", ""));
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -168,7 +168,7 @@ public abstract class BuildServerDataProvider {
 
   protected void maybePut(@Nonnull Properties properties, @Nonnull String key, Supplier<String> supplier) {
     String keyWithPrefix = prefixDot + key;
-    if (properties.containsKey(keyWithPrefix)) {
+    if (properties.stringPropertyNames().contains(keyWithPrefix)) {
       String propertyValue = properties.getProperty(keyWithPrefix);
       log.info("Using cached {} with value {}", keyWithPrefix, propertyValue);
     } else if (PropertiesFilterer.isIncluded(keyWithPrefix, includeOnlyProperties, excludeProperties)) {

--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -166,12 +166,6 @@ public abstract class BuildServerDataProvider {
     maybePut(properties, GitCommitPropertyConstant.BUILD_HOST, buildHostSupplier);
   }
 
-  protected void put(@Nonnull Properties properties, @Nonnull String key, String value) {
-    String keyWithPrefix = prefixDot + key;
-    log.info("Collected {} with value {}", keyWithPrefix, value);
-    PropertyManager.putWithoutPrefix(properties, keyWithPrefix, value);
-  }
-
   protected void maybePut(@Nonnull Properties properties, @Nonnull String key, Supplier<String> supplier) {
     String keyWithPrefix = prefixDot + key;
     if (properties.containsKey(keyWithPrefix)) {

--- a/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
@@ -40,7 +40,7 @@ public class CircleCiBuildServerData extends BuildServerDataProvider {
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
     String buildNumber = env.getOrDefault("CIRCLE_BUILD_NUM", "");
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/GitlabBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/GitlabBuildServerData.java
@@ -46,8 +46,8 @@ public class GitlabBuildServerData extends BuildServerDataProvider {
     // CI_PIPELINE_IID will be present if in a Gitlab CI environment (Gitlab >11.0) and contains the project specific build number
     String buildNumber = env.getOrDefault("CI_PIPELINE_IID", "");
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, uniqueBuildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, () -> uniqueBuildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
@@ -42,7 +42,7 @@ public class HudsonJenkinsBuildServerData extends BuildServerDataProvider {
   void loadBuildNumber(@Nonnull Properties properties) {
     String buildNumber = env.getOrDefault("BUILD_NUMBER", "");
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/TeamCityBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/TeamCityBuildServerData.java
@@ -54,8 +54,8 @@ public class TeamCityBuildServerData extends BuildServerDataProvider {
     String buildNumber = env.getOrDefault("BUILD_NUMBER", "");
     String buildNumberUnique = teamcitySystemProperties.getProperty("teamcity.build.id", "");
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, buildNumberUnique);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, () -> buildNumberUnique);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/cibuild/TravisBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/TravisBuildServerData.java
@@ -42,8 +42,8 @@ public class TravisBuildServerData extends BuildServerDataProvider {
     String buildNumber = env.getOrDefault("TRAVIS_BUILD_NUMBER", "");
     String uniqueBuildNumber = env.getOrDefault("TRAVIS_BUILD_ID", "");
 
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber);
-    put(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, uniqueBuildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, () -> uniqueBuildNumber);
   }
 
   @Override

--- a/core/src/main/java/pl/project13/core/util/PropertyManager.java
+++ b/core/src/main/java/pl/project13/core/util/PropertyManager.java
@@ -30,7 +30,7 @@ public class PropertyManager {
     if (!isNotEmpty(value)) {
       value = "Unknown";
     }
-    properties.put(key, value);
+    properties.setProperty(key, value);
   }
 
   private static boolean isNotEmpty(@Nullable String value) {

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -564,7 +564,9 @@ public class GitCommitIdMojo extends AbstractMojo {
   }
 
   private void publishPropertiesInto(Properties p) {
-    p.putAll(properties);
+    for (String propertyName : properties.stringPropertyNames()) {
+      p.setProperty(propertyName, properties.getProperty(propertyName));
+    }
   }
 
   /**
@@ -603,9 +605,8 @@ public class GitCommitIdMojo extends AbstractMojo {
   }
 
   private void logProperties() {
-    for (Object key : properties.keySet()) {
-      String keyString = key.toString();
-      log.info("including property {} in results", keyString);
+    for (String propertyName : properties.stringPropertyNames()) {
+      log.info("including property {} in results", propertyName);
     }
   }
 

--- a/maven/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
+++ b/maven/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
@@ -50,21 +50,18 @@ public class PropertiesReplacer {
   }
 
   private void performReplacementOnAllGeneratedProperties(Properties properties, ReplacementProperty replacementProperty) {
-    Map<Object, Object> propertiesToBeAdded = new HashMap<>();
-    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-      String key = (String)entry.getKey();
-      String content = (String)entry.getValue();
+    for (String propertyName : properties.stringPropertyNames()) {
+      String content = properties.getProperty(propertyName);
       String result = performReplacement(replacementProperty, content);
       if ((replacementProperty.getPropertyOutputSuffix() != null) && (!replacementProperty.getPropertyOutputSuffix().isEmpty())) {
-        String newPropertyKey = key + "." + replacementProperty.getPropertyOutputSuffix();
-        propertiesToBeAdded.put(newPropertyKey, result);
-        log.info("apply replace on property " + key + " and save to " + newPropertyKey + ": original value '" + content + "' with '" + result + "'");
+        String newPropertyKey = propertyName + "." + replacementProperty.getPropertyOutputSuffix();
+        properties.setProperty(newPropertyKey, result);
+        log.info("apply replace on property " + propertyName + " and save to " + newPropertyKey + ": original value '" + content + "' with '" + result + "'");
       } else {
-        entry.setValue(result);
-        log.info("apply replace on property " + key + ": original value '" + content + "' with '" + result + "'");
+        properties.setProperty(propertyName, result);
+        log.info("apply replace on property " + propertyName + ": original value '" + content + "' with '" + result + "'");
       }
     }
-    properties.putAll(propertiesToBeAdded);
   }
 
   private void performReplacementOnSingleProperty(Properties properties, ReplacementProperty replacementProperty, String propertyKey) {


### PR DESCRIPTION
Changes the build system information to be conditionally set within the properties. In multi-threaded builds, without the optional put, a ConcurrentModificationException occurs as this information is written at the same time the object is being iterated over.

### Context
Fixes #469.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
