### PR TITLE
#509: Allow initial 'git.build.time' from 'project.build.outputTimestamp' to support reproducible builds

### DIFF
--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -23,6 +23,7 @@ import pl.project13.core.log.LoggerBridge;
 import pl.project13.core.util.PropertyManager;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
@@ -112,8 +113,8 @@ public abstract class BuildServerDataProvider {
     return new UnknownBuildServerData(log, env);
   }
 
-  public void loadBuildData(@Nonnull Properties properties) {
-    loadBuildVersionAndTimeData(properties);
+  public void loadBuildData(@Nonnull Properties properties, @Nullable Date reproducibleBuildOutputTimestamp) {
+    loadBuildVersionAndTimeData(properties, reproducibleBuildOutputTimestamp);
     loadBuildHostData(properties);
     loadBuildNumber(properties);
   }
@@ -132,9 +133,9 @@ public abstract class BuildServerDataProvider {
    */
   public abstract String getBuildBranch();
 
-  private void loadBuildVersionAndTimeData(@Nonnull Properties properties) {
+  private void loadBuildVersionAndTimeData(@Nonnull Properties properties, @Nullable Date reproducibleBuildOutputTimestamp) {
     Supplier<String> buildTimeSupplier = () -> {
-      Date buildDate = new Date();
+      Date buildDate = (reproducibleBuildOutputTimestamp == null) ? new Date() : reproducibleBuildOutputTimestamp;
       SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
       if (dateFormatTimeZone != null) {
         smf.setTimeZone(TimeZone.getTimeZone(dateFormatTimeZone));

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Supplier;
@@ -373,6 +375,18 @@ public class GitCommitIdMojo extends AbstractMojo {
   boolean offline;
 
   /**
+   * Timestamp for reproducible output archive entries
+   * (https://maven.apache.org/guides/mini/guide-reproducible-builds.html).
+   * The value from <code>${project.build.outputTimestamp}</code> is either formatted as ISO 8601
+   * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+   * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>.
+   *
+   * @since 4.0.2
+   */
+  @Parameter(defaultValue = "${project.build.outputTimestamp}")
+  private String projectBuildOutputTimestamp;
+
+  /**
    * Injected {@link BuildContext} to recognize incremental builds.
    */
   @Component
@@ -548,7 +562,7 @@ public class GitCommitIdMojo extends AbstractMojo {
     return null;
   }
 
-  private void loadBuildData(Properties properties) {
+  private void loadBuildData(Properties properties) throws GitCommitIdExecutionException {
     Map<String, Supplier<String>> additionalProperties = Collections.singletonMap(
             GitCommitPropertyConstant.BUILD_VERSION, () -> project.getVersion());
     BuildServerDataProvider buildServerDataProvider = BuildServerDataProvider.getBuildServerProvider(System.getenv(),log);
@@ -560,7 +574,40 @@ public class GitCommitIdMojo extends AbstractMojo {
         .setExcludeProperties(excludeProperties)
         .setIncludeOnlyProperties(includeOnlyProperties);
 
-    buildServerDataProvider.loadBuildData(properties);
+    buildServerDataProvider.loadBuildData(properties, parseOutputTimestamp(projectBuildOutputTimestamp));
+  }
+
+  /**
+   * Parse output timestamp configured for Reproducible Builds' archive entries
+   * (https://maven.apache.org/guides/mini/guide-reproducible-builds.html).
+   * The value from <code>${project.build.outputTimestamp}</code> is either formatted as ISO 8601
+   * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+   * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>.
+   *
+   * Inspired by https://github.com/apache/maven-archiver/blob/a3103d99396cd8d3440b907ef932a33563225265/src/main/java/org/apache/maven/archiver/MavenArchiver.java#L765
+   *
+   * @param outputTimestamp the value of <code>${project.build.outputTimestamp}</code> (may be <code>null</code>)
+   * @return the parsed timestamp, may be <code>null</code> if <code>null</code> input or input contains only 1
+   *         character
+   */
+  private Date parseOutputTimestamp(String outputTimestamp) throws GitCommitIdExecutionException {
+    if (outputTimestamp != null && !outputTimestamp.trim().isEmpty() && outputTimestamp.chars().allMatch(Character::isDigit)) {
+      return new Date(Long.parseLong(outputTimestamp) * 1000);
+    }
+
+    if ((outputTimestamp == null) || (outputTimestamp.length() < 2)) {
+      // no timestamp configured
+      return null;
+    }
+
+    DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ssXXX");
+    try {
+      return df.parse(outputTimestamp);
+    } catch (ParseException pe) {
+      throw new GitCommitIdExecutionException(
+              "Invalid 'project.build.outputTimestamp' value '" + outputTimestamp + "'",
+              pe);
+    }
   }
 
   private void publishPropertiesInto(Properties p) {

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -600,7 +600,7 @@ public class GitCommitIdMojo extends AbstractMojo {
       return null;
     }
 
-    DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ssXXX");
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
     try {
       return df.parse(outputTimestamp);
     } catch (ParseException pe) {


### PR DESCRIPTION
Untested :-)

Refs #509: Allow initial 'git.build.time' from 'project.build.outputTimestamp' to support reproducible builds