### PR TITLE
#519: fix an issue where special characters in the git URL simply yield: Illegal character in authority

### DIFF
--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -288,7 +288,7 @@ public abstract class GitDataProvider implements GitProvider {
    * <a href=https://www.ietf.org/rfc/rfc2396.txt>RFC-2396</a> in section "3.2.2. Server-based Naming Authority"
    * which declares the following as valid URL schema:
    *  <pre>
-   *  <userinfo>@<host>:<port>
+   *  &lt;userinfo&gt;@&lt;host&gt;:&lt;port&gt;
    *  </pre>
    *  The "userinfo" part is declared in the same section allowing the following pattern:
    *  <pre>

--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -25,6 +25,8 @@ import pl.project13.core.util.PropertyManager;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.text.SimpleDateFormat;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -299,6 +301,15 @@ public abstract class GitDataProvider implements GitProvider {
     }
     // At this point, we should have a properly formatted URL
     try {
+
+      for (String s: Arrays.asList(
+              // escape all 'delims' characters in a URI as per https://www.ietf.org/rfc/rfc2396.txt
+              "<", ">", "#", "%", "\"",
+              // escape all 'unwise' characters in a URI as per https://www.ietf.org/rfc/rfc2396.txt
+              "{", "}", "|", "\\", "^", "[", "]", "`")) {
+        gitRemoteString = gitRemoteString.replaceAll(
+                Pattern.quote(s), URLEncoder.encode(s, StandardCharsets.UTF_8.toString()));
+      }
       URI original = new URI(gitRemoteString);
       String userInfoString = original.getUserInfo();
       if (null == userInfoString) {

--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -281,6 +281,31 @@ public abstract class GitDataProvider implements GitProvider {
   /**
    * If the git remote value is a URI and contains a user info component, strip the password from it if it exists.
    *
+   * Note that this method will return an empty string if any failure occurred, while stripping the password from the
+   * credentials. This merely serves as save-guard to avoid any potential password exposure inside generated properties.
+   *
+   * This method further operates on the assumption that a valid URL schema follows the rules outlined in
+   * <a href=https://www.ietf.org/rfc/rfc2396.txt>RFC-2396</a> in section "3.2.2. Server-based Naming Authority"
+   * which declares the following as valid URL schema:
+   *  <pre>
+   *  <userinfo>@<host>:<port>
+   *  </pre>
+   *  The "userinfo" part is declared in the same section allowing the following pattern:
+   *  <pre>
+   *    userinfo = *( unreserved | escaped | ";" | ":" | "&" | "=" | "+" | "$" | "," )
+   *  </pre>
+   *  The "unreserved" part is declared in section "2.3. Unreserved Characters" as the following:
+   *  <pre>
+   *    unreserved  = alphanum | mark
+   *    mark = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
+   *
+   *    alphanum = alpha | digit
+   *    digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |  "8" | "9"
+   *    alpha = lowalpha | upalpha
+   *    lowalpha = "a" | "b" | "c" | ... | "x" | "y" | "z"
+   *    upalpha = "A" | "B" | "C" | ... | "X" | "Y" | "Z"
+   *  </pre>
+   *
    * @param gitRemoteString The value of the git remote
    * @return returns the gitRemoteUri with stripped password (might be used in http or https)
    * @throws GitCommitIdExecutionException Exception when URI is invalid

--- a/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
+++ b/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
@@ -52,6 +52,8 @@ public class UriUserInfoRemoverTest {
             { "file:///path/to/repo.git/", "file:///path/to/repo.git/"},
             { "file:///C:\\Users\\test\\example", "file:///C:\\Users\\test\\example"},
             { "file://C:\\Users\\test\\example", "file://C:\\Users\\test\\example" },
+            // ensure a percent encoded password is stripped too, that should be allowed
+            { "https://user:passw%40rd@example.com:8888", "https://user@example.com:8888" },
             // Must Support: use of 'unreserved' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.3. Unreserved Characters"
             { "https://user:A-_.!~*'()Z@example.com:8888", "https://user@example.com:8888" },
             // Optional Support: use of 'reserved' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.2. Reserved Characters"

--- a/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
+++ b/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
@@ -52,6 +52,15 @@ public class UriUserInfoRemoverTest {
             { "file:///path/to/repo.git/", "file:///path/to/repo.git/"},
             { "file:///C:\\Users\\test\\example", "file:///C:\\Users\\test\\example"},
             { "file://C:\\Users\\test\\example", "file://C:\\Users\\test\\example" },
+            // use of 'reserved' characters as https://www.ietf.org/rfc/rfc2396.txt
+            // note: left out '/' since we can't simply escape it
+            { "https://user:A;?:@&=+$,Z@example.com:8888", "https://user@example.com:8888" },
+            // use of 'unreserved' characters as https://www.ietf.org/rfc/rfc2396.txt
+            { "https://user:A-_.!~*'()Z@example.com:8888", "https://user@example.com:8888" },
+            // use of 'delims' characters as https://www.ietf.org/rfc/rfc2396.txt
+            { "https://user:A<>#%\"Z@example.com:8888", "https://user@example.com:8888" },
+            // use of 'unwise' characters as https://www.ietf.org/rfc/rfc2396.txt
+            { "https://user:A{}|\\^[]`Z@example.com:8888", "https://user@example.com:8888" },
     };
     return Arrays.asList(data);
   }

--- a/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
+++ b/maven/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
@@ -52,14 +52,14 @@ public class UriUserInfoRemoverTest {
             { "file:///path/to/repo.git/", "file:///path/to/repo.git/"},
             { "file:///C:\\Users\\test\\example", "file:///C:\\Users\\test\\example"},
             { "file://C:\\Users\\test\\example", "file://C:\\Users\\test\\example" },
-            // use of 'reserved' characters as https://www.ietf.org/rfc/rfc2396.txt
-            // note: left out '/' since we can't simply escape it
-            { "https://user:A;?:@&=+$,Z@example.com:8888", "https://user@example.com:8888" },
-            // use of 'unreserved' characters as https://www.ietf.org/rfc/rfc2396.txt
+            // Must Support: use of 'unreserved' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.3. Unreserved Characters"
             { "https://user:A-_.!~*'()Z@example.com:8888", "https://user@example.com:8888" },
-            // use of 'delims' characters as https://www.ietf.org/rfc/rfc2396.txt
+            // Optional Support: use of 'reserved' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.2. Reserved Characters"
+            // note: left out '/', '?', '@' since we technically expect user's need to escape those
+            { "https://user:A;:&=+$,Z@example.com:8888", "https://user@example.com:8888" },
+            // Optional Support: use of 'delims' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.4.3. Excluded US-ASCII Characters"
             { "https://user:A<>#%\"Z@example.com:8888", "https://user@example.com:8888" },
-            // use of 'unwise' characters as https://www.ietf.org/rfc/rfc2396.txt
+            // Optional Support: use of 'unwise' characters as https://www.ietf.org/rfc/rfc2396.txt, Section "2.4.3. Excluded US-ASCII Characters"
             { "https://user:A{}|\\^[]`Z@example.com:8888", "https://user@example.com:8888" },
     };
     return Arrays.asList(data);


### PR DESCRIPTION

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->
Refs #519.

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
