### PR TITLE
Update JGit dependency to 5.9.0.202009080501

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.target>1.8</java.target>
 
-        <jgit.version>5.8.1.202007141445-r</jgit.version>
+        <jgit.version>5.9.0.202009080501-r</jgit.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Includes bug fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=564202 which broke https://github.com/prestosql/presto builds