### PR TITLE
fix javadoc generation for java 12 / 13

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,6 +21,21 @@
         <junit.version>4.13.1</junit.version>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- Setting built-in java compiler properties -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.target}</source>
+                    <target>${java.target}</target>
+                    <compilerArgument>-Xlint:deprecation</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- JGit -->
         <dependency>

--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -221,6 +221,7 @@ public abstract class GitDataProvider implements GitProvider {
    *
    * @param env environment settings
    * @return results of getBranchName() or, if in Jenkins/Hudson, value of GIT_BRANCH
+   * @throws GitCommitIdExecutionException the branch name could not be determined
    */
   protected String determineBranchName(@Nonnull Map<String, String> env) throws GitCommitIdExecutionException {
     BuildServerDataProvider buildServerDataProvider = BuildServerDataProvider.getBuildServerProvider(env,log);

--- a/core/src/main/java/pl/project13/core/NativeGitProvider.java
+++ b/core/src/main/java/pl/project13/core/NativeGitProvider.java
@@ -371,10 +371,24 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   public interface ProcessRunner {
-    /** Run a command and return the entire output as a String - naive, we know. */
+    /** Run a command and return the entire output as a String - naive, we know.
+     *
+     * @param directory the directory where the command should be executed in
+     * @param nativeGitTimeoutInMs the timeout in milliseconds before the command get's terminated
+     * @param command the command to execute
+     * @return the output obtained from stdout by running the command
+     * @throws IOException the command execution failed
+     */
     String run(File directory, long nativeGitTimeoutInMs, String command) throws IOException;
 
-    /** Run a command and return false if it contains at least one output line*/
+    /** Run a command and return false if it contains at least one output line
+     *
+     * @param directory the directory where the command should be executed in
+     * @param nativeGitTimeoutInMs the timeout in milliseconds before the command get's terminated
+     * @param command the command to execute
+     * @return false if the output of the command contains at least one line on stdout, true otherwise
+     * @throws IOException the command execution failed
+     */
     boolean runEmpty(File directory, long nativeGitTimeoutInMs, String command) throws IOException;
   }
 

--- a/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AwsCodeBuildBuildServerData.java
@@ -31,6 +31,8 @@ public class AwsCodeBuildBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the AWS specific environment variable; false otherwise
    * @see <a href="https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html">Environment variables in build environments</a>
    */
   public static boolean isActiveServer(Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/AzureDevOpsBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/AzureDevOpsBuildServerData.java
@@ -31,6 +31,8 @@ public class AzureDevOpsBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Azure specific environment variable; false otherwise
    * @see <a href="https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables">Azure DevOps - Build variables</a>
    */
   public static boolean isActiveServer(@Nonnull Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
@@ -29,6 +29,11 @@ public class BambooBuildServerData extends BuildServerDataProvider {
     super(log, env);
   }
 
+  /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Bamboo specific environment variable; false otherwise
+   * @see <a href="https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables">Bamboo Variables</a>
+   */
   public static boolean isActiveServer(Map<String, String> env) {
     return env.containsKey("bamboo_buildKey") ||
             env.containsKey("bamboo.buildKey") ||

--- a/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
@@ -31,6 +31,8 @@ public class CircleCiBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Circle CI specific environment variable; false otherwise
    * @see <a href="https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables">CircleCIBuiltInVariables</a>
    */
   public static boolean isActiveServer(Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
@@ -33,6 +33,8 @@ public class GitHubBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Github specific environment variable; false otherwise
    * @see <a href="https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables">GitHubActionsUsingEnvironmentVariables</a>
    */
   public static boolean isActiveServer(Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/GitlabBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/GitlabBuildServerData.java
@@ -31,6 +31,8 @@ public class GitlabBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Gitlab specific environment variable; false otherwise
    * @see <a href="https://docs.gitlab.com/ce/ci/variables/predefined_variables.html">GitlabCIVariables</a>
    */
   public static boolean isActiveServer(Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/HudsonJenkinsBuildServerData.java
@@ -31,6 +31,8 @@ public class HudsonJenkinsBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Hudson/Jenkins specific environment variable; false otherwise
    * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables">JenkinsSetEnvironmentVariables</a>
    */
   public static boolean isActiveServer(@Nonnull Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/TeamCityBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/TeamCityBuildServerData.java
@@ -43,6 +43,8 @@ public class TeamCityBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the TeamCity specific environment variable; false otherwise
    * @see <a href=https://confluence.jetbrains.com/display/TCD18/Predefined+Build+Parameters#PredefinedBuildParameters-ServerBuildProperties>TeamCity</a>
    */
   public static boolean isActiveServer(@Nonnull Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/cibuild/TravisBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/TravisBuildServerData.java
@@ -31,6 +31,8 @@ public class TravisBuildServerData extends BuildServerDataProvider {
   }
 
   /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Travis specific environment variable; false otherwise
    * @see <a href=https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables>Travis</a>
    */
   public static boolean isActiveServer(@Nonnull Map<String, String> env) {

--- a/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
+++ b/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
@@ -79,6 +79,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * @param evaluateOnCommit the commit that should be used as reference to generate the properties from
    * @param repo the {@link Repository} this command should interact with
    * @param log logger bridge to direct logs to
+   * @return itself with the options set as specified by the arguments to allow fluent configuration
    */
   @Nonnull
   public static DescribeCommand on(String evaluateOnCommit, Repository repo, LoggerBridge log) {
@@ -91,6 +92,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * @param evaluateOnCommit the commit that should be used as reference to generate the properties from
    * @param repo the {@link Repository} this command should interact with
    * @param log logger bridge to direct logs to
+   * @return itself with the options set as specified by the arguments to allow fluent configuration
    */
   private DescribeCommand(@Nonnull String evaluateOnCommit, @Nonnull Repository repo, @Nonnull LoggerBridge log) {
     super(repo);

--- a/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
+++ b/core/src/main/java/pl/project13/core/jgit/DescribeCommand.java
@@ -76,6 +76,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   /**
    * Creates a new describe command which interacts with a single repository
    *
+   * @param evaluateOnCommit the commit that should be used as reference to generate the properties from
    * @param repo the {@link Repository} this command should interact with
    * @param log logger bridge to direct logs to
    */
@@ -87,7 +88,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   /**
    * Creates a new describe command which interacts with a single repository
    *
-   * @param repo the {@link org.eclipse.jgit.lib.Repository} this command should interact with
+   * @param evaluateOnCommit the commit that should be used as reference to generate the properties from
+   * @param repo the {@link Repository} this command should interact with
+   * @param log logger bridge to direct logs to
    */
   private DescribeCommand(@Nonnull String evaluateOnCommit, @Nonnull Repository repo, @Nonnull LoggerBridge log) {
     super(repo);
@@ -102,6 +105,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * Show uniquely abbreviated commit object as fallback.
    *
    * <pre>true</pre> by default.
+   *
+   * @param always set to `true` when you want the describe command show uniquely abbreviated commit object as fallback.
+   * @return itself with the `--always` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand always(boolean always) {
@@ -120,6 +126,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * since tag v1.2 that points at object deadbee....).
    *
    * <pre>false</pre> by default.
+   *
+   * @param forceLongFormat set to `true` if you always want to output the long format
+   * @return itself with the `--long` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand forceLongFormat(@Nullable Boolean forceLongFormat) {
@@ -137,6 +146,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * use <b>N</b> digits, or as many digits as needed to form a unique object name.
    *
    * An `n` of 0 will suppress long format, only showing the closest tag.
+   *
+   * @param n the length of the abbreviated object name
+   * @return itself with the `--abbrev` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand abbrev(@Nullable Integer n) {
@@ -180,6 +192,9 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * things like "i'll get back to that" etc - you don't need such tags to be exposed. But if you want lightweight
    * tags to be included in the search, enable this option.
    * </p>
+   *
+   * @param includeLightweightTagsInSearch set to `true` if you want to matching a lightweight (non-annotated) tag
+   * @return itself with the `--tags` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand tags(@Nullable Boolean includeLightweightTagsInSearch) {
@@ -192,6 +207,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
 
   /**
    * Alias for {@link DescribeCommand#tags(Boolean)} with <b>true</b> value
+   * @return itself with the `--tags` option set to `true` to allow fluent configuration
    */
   public DescribeCommand tags() {
     return tags(true);
@@ -201,6 +217,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * Apply all configuration options passed in with `config`.
    * If a setting is null, it will not be applied - so for abbrev for example, the default 7 would be used.
    *
+   * @param config A configuration that shall be applied to the current one
    * @return itself, after applying the settings
    */
   @Nonnull
@@ -222,7 +239,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * working tree is dirty.
    *
    * @param dirtyMarker the marker name to be appended to the describe output when the workspace is dirty
-   * @return itself, to allow fluent configuration
+   * @return itself with the `--dirty` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand dirty(@Nullable String dirtyMarker) {
@@ -237,7 +254,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * Consider only those tags which match the given glob pattern.
    *
    * @param pattern the glob style pattern to match against the tag names
-   * @return itself, to allow fluent configuration
+   * @return itself with the `--match` option set as specified by the argument to allow fluent configuration
    */
   @Nonnull
   public DescribeCommand match(@Nullable String pattern) {
@@ -306,6 +323,12 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
    * and will fallback to a plain commit hash if nothing better is returnable.
    *
    * The exact logic is following what <pre>git-describe</pre> would do.
+   *
+   * @param objectReader A reader to read objects from {@link Repository#getObjectDatabase()}.
+   * @param headCommitId An unique hash of the head-commit
+   * @param dirty An indication if the current repository is considered <pre>dirty</pre>
+   * @param howFarFromWhichTag A Pair that consists of a string and an integer. The String represents the closest Tag and the integer the amount of commits that have been preformed since then
+   * @return The result of a <code>git describe</code> command with the specified settings.
    */
   private DescribeResult createDescribeResult(ObjectReader objectReader, ObjectId headCommitId, boolean dirty, @Nullable Pair<Integer, String> howFarFromWhichTag) {
     if (howFarFromWhichTag == null) {

--- a/core/src/main/java/pl/project13/core/jgit/DescribeResult.java
+++ b/core/src/main/java/pl/project13/core/jgit/DescribeResult.java
@@ -175,6 +175,8 @@ public class DescribeResult {
    * a longer one will be used (which WILL guarantee uniqueness).
    * If you need the full commit id, it's always available via {@link DescribeResult#commitObjectId()}.
    * </p>
+   *
+   * @return The (possibly) "g" prefixed <strong>abbreviated</strong> object id of a commit.
    */
   @Nullable
   public String prefixedCommitId() {

--- a/core/src/main/java/pl/project13/core/jgit/JGitCommon.java
+++ b/core/src/main/java/pl/project13/core/jgit/JGitCommon.java
@@ -264,7 +264,9 @@ public class JGitCommon {
 
   /**
    * Calculates the distance (number of commits) between the given parent and child commits.
-   *
+   * @param repo the {@link Repository} this command should interact with
+   * @param child the child commit (starting point)
+   * @param parent the parent commit (end point)
    * @return distance (number of commits) between the given commits
    * @see <a href="https://github.com/mdonoughe/jgit-describe/blob/master/src/org/mdonoughe/JGitDescribeTask.java">mdonoughe/jgit-describe/blob/master/src/org/mdonoughe/JGitDescribeTask.java</a>
    */

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

The [current build](https://github.com/git-commit-id/git-commit-id-maven-plugin/runs/1311745645) is failing due to 'broken' javadoc. This MR fixes those complaints.

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
