### PR TITLE
#531: session.getProjectDependencyGraph() might be `null` when running the plugin from eclipse

### DIFF
--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -68,25 +68,25 @@ public class GitCommitIdMojo extends AbstractMojo {
   /**
    * The list of projects in the reactor.
    */
-  @Parameter(defaultValue = "${reactorProjects}", readonly = true)
+  @Parameter(defaultValue = "${reactorProjects}", readonly = true, required = true)
   List<MavenProject> reactorProjects;
 
   /**
    * The Mojo Execution
    */
-  @Parameter(defaultValue = "${mojoExecution}", readonly = true)
+  @Parameter(defaultValue = "${mojoExecution}", readonly = true, required = true)
   MojoExecution mojoExecution;
 
   /**
    * The Maven Session Object.
    */
-  @Parameter(property = "session", required = true, readonly = true)
+  @Parameter(defaultValue = "${session}", readonly = true, required = true)
   MavenSession session;
 
   /**
    * The Maven settings.
    */
-  @Parameter(property = "settings", required = true, readonly = true)
+  @Parameter(defaultValue = "${settings}", readonly = true, required = true)
   Settings settings;
 
   /**

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -438,7 +438,13 @@ public class GitCommitIdMojo extends AbstractMojo {
       }
 
       if (runOnlyOnce) {
-        List<MavenProject> sortedProjects = session.getProjectDependencyGraph().getSortedProjects();
+        List<MavenProject> sortedProjects =
+                Optional.ofNullable(session.getProjectDependencyGraph())
+                        .map(graph -> graph.getSortedProjects())
+                        .orElseGet(() -> {
+                          log.warn("Maven's dependency graph is null. Assuming project is the only one executed.");
+                          return Collections.singletonList(session.getCurrentProject());
+                        });
         MavenProject firstProject = sortedProjects.stream()
                 // skipPoms == true => find first project that is not pom project
                 .filter(p -> {


### PR DESCRIPTION
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
