### PR TITLE
Support Bitbucket Pipelines CI for build number and branch

### DIFF
--- a/core/src/main/java/pl/project13/core/cibuild/BitbucketBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BitbucketBuildServerData.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.core.cibuild;
+
+import pl.project13.core.GitCommitPropertyConstant;
+import pl.project13.core.log.LoggerBridge;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import javax.annotation.Nonnull;
+
+public class BitbucketBuildServerData extends BuildServerDataProvider {
+
+  BitbucketBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
+    super(log, env);
+  }
+
+  /**
+   * @param env The current system environment variables, obtained via System.getenv().
+   * @return true, if the system environment variables contain the Bitbucket specific environment variable; false otherwise
+   * @see <a href="https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/">Bitbucket Variables</a>
+   */
+  public static boolean isActiveServer(Map<String, String> env) {
+    return env.containsKey("BITBUCKET_BUILD_NUMBER");
+  }
+
+  @Override
+  void loadBuildNumber(@Nonnull Properties properties) {
+    String buildNumber = Optional.ofNullable(env.get("BITBUCKET_BUILD_NUMBER")).orElse("");
+
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
+  }
+
+  @Override
+  public String getBuildBranch() {
+    String environmentBasedKey = null;
+
+    String envKey = "BITBUCKET_BRANCH";
+    String environmentBasedBranch = env.get(envKey);
+    if (environmentBasedBranch != null) {
+      environmentBasedKey = envKey;
+    }
+    log.info("Using environment variable based branch name. {} = {}", environmentBasedKey, environmentBasedBranch);
+    return environmentBasedBranch;
+  }
+}

--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -110,6 +110,9 @@ public abstract class BuildServerDataProvider {
     if (AwsCodeBuildBuildServerData.isActiveServer(env)) {
       return new AwsCodeBuildBuildServerData(log, env);
     }
+    if (BitbucketBuildServerData.isActiveServer(env)) {
+      return new BitbucketBuildServerData(log, env);
+    }
     return new UnknownBuildServerData(log, env);
   }
 

--- a/maven/docs/using-the-plugin.md
+++ b/maven/docs/using-the-plugin.md
@@ -914,6 +914,6 @@ Refer to the table below to see which values are supported by which CIs.
  
  | variable                  | description                             | supported CIs                                             |    
  | ------------------------- | ----------------------------------------|:---------------------------------------------------------:|   
- |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5), Azure DevOps, AWS CodeBuild |        
+ |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5), Azure DevOps, AWS CodeBuild, Bitbucket Pipelines |        
  |`git.build.number.unique`  | holds a system wide unique build number | TeamCity, Travis, Gitlab CI (Gitlab >11.0), AWS CodeBuild |
 


### PR DESCRIPTION
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->
The Bitbucket Pipelines CI is not currently supported. This small change borrows from BambooBuilderServerData, and adds BitbucketBuilderServerData to support the CI. The documented environment variables are at [Variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)


### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
