### PR TITLE
add support for author and commiter times

### DIFF
--- a/core/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
+++ b/core/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
@@ -41,6 +41,8 @@ public class GitCommitPropertyConstant {
   public static final String COMMIT_MESSAGE_FULL = "commit.message.full";
   public static final String COMMIT_MESSAGE_SHORT = "commit.message.short";
   public static final String COMMIT_TIME = "commit.time";
+  public static final String COMMIT_AUTHOR_TIME = "commit.author.time";
+  public static final String COMMIT_COMMITTER_TIME = "commit.committer.time";
   public static final String REMOTE_ORIGIN_URL = "remote.origin.url";
   public static final String TAGS = "tags";
   public static final String CLOSEST_TAG_NAME = "closest.tag.name";

--- a/core/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/core/src/main/java/pl/project13/core/GitDataProvider.java
@@ -159,6 +159,10 @@ public abstract class GitDataProvider implements GitProvider {
       maybePut(properties, GitCommitPropertyConstant.COMMIT_MESSAGE_SHORT, this::getCommitMessageShort);
       // git.commit.time
       maybePut(properties, GitCommitPropertyConstant.COMMIT_TIME, this::getCommitTime);
+      // commit.author.time
+      maybePut(properties, GitCommitPropertyConstant.COMMIT_AUTHOR_TIME, this::getCommitAuthorTime);
+      // commit.committer.time
+      maybePut(properties, GitCommitPropertyConstant.COMMIT_COMMITTER_TIME, this::getCommitAuthorTime);
       // git remote.origin.url
       maybePut(properties, GitCommitPropertyConstant.REMOTE_ORIGIN_URL, this::getRemoteOriginUrl);
 

--- a/core/src/main/java/pl/project13/core/GitProvider.java
+++ b/core/src/main/java/pl/project13/core/GitProvider.java
@@ -43,6 +43,10 @@ public interface GitProvider {
 
   String getCommitAuthorEmail() throws GitCommitIdExecutionException;
 
+  String getCommitAuthorTime() throws GitCommitIdExecutionException;
+
+  String getCommitCommitterTime() throws GitCommitIdExecutionException;
+
   String getCommitMessageFull() throws GitCommitIdExecutionException;
 
   String getCommitMessageShort() throws GitCommitIdExecutionException;

--- a/core/src/main/java/pl/project13/core/JGitProvider.java
+++ b/core/src/main/java/pl/project13/core/JGitProvider.java
@@ -216,6 +216,20 @@ public class JGitProvider extends GitDataProvider {
   }
 
   @Override
+  public String getCommitAuthorTime() throws GitCommitIdExecutionException {
+    Date commitAuthorDate = evalCommit.getAuthorIdent().getWhen();
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
+    return smf.format(commitAuthorDate);
+  }
+
+  @Override
+  public String getCommitCommitterTime() throws GitCommitIdExecutionException {
+    Date commitCommitterDate = evalCommit.getCommitterIdent().getWhen();
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
+    return smf.format(commitCommitterDate);
+  }
+
+  @Override
   public String getRemoteOriginUrl() throws GitCommitIdExecutionException {
     String url = git.getConfig().getString("remote", "origin", "url");
     return stripCredentialsFromOriginUrl(url);
@@ -329,7 +343,7 @@ public class JGitProvider extends GitDataProvider {
 
     return repository;
   }
-  
+
   @Override
   public AheadBehind getAheadBehind() throws GitCommitIdExecutionException {
     try {

--- a/core/src/main/java/pl/project13/core/NativeGitProvider.java
+++ b/core/src/main/java/pl/project13/core/NativeGitProvider.java
@@ -256,6 +256,20 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   @Override
+  public String getCommitAuthorTime() throws GitCommitIdExecutionException {
+    String value =  runQuietGitCommand(canonical, nativeGitTimeoutInMs, "log -1 --pretty=format:%at " + evaluateOnCommit);
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
+    return smf.format(Long.parseLong(value) * 1000L);
+  }
+
+  @Override
+  public String getCommitCommitterTime() throws GitCommitIdExecutionException {
+    String value =  runQuietGitCommand(canonical, nativeGitTimeoutInMs, "log -1 --pretty=format:%ct " + evaluateOnCommit);
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
+    return smf.format(Long.parseLong(value) * 1000L);
+  }
+
+  @Override
   public String getTags() throws GitCommitIdExecutionException {
     final String result = runQuietGitCommand(canonical, nativeGitTimeoutInMs, "tag --contains " + evaluateOnCommit);
     return result.replace('\n', ',');

--- a/maven/docs/using-the-plugin.md
+++ b/maven/docs/using-the-plugin.md
@@ -894,6 +894,8 @@ Generated properties
  |`git.commit.message.full`      | Represents the raw body (unwrapped subject and body) of the commit message (`git log -1 --pretty=format:%B`) |
  |`git.commit.message.short`     | Represents the subject of the commit message - may *not* be suitable for filenames (`git log -1 --pretty=format:%s`) |
  |`git.commit.time`              | Represents the (formatted) time stamp when the commit has been performed. |
+ |`git.commit.committer.time`       | Represents the (formatted) time stamp when the commit has been performed. |
+ |`git.commit.author.time`       | Represents the (formatted) time stamp when the commit has been originally performed. |
  |`git.commit.user.email`        | Represents the user eMail of the user who performed the commit. |
  |`git.commit.user.name`         | Represents the user name of the user who performed the commit. |
  |`git.dirty`                    | A working tree is said to be "dirty" if it contains modifications which have not been committed to the current branch. |

--- a/maven/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
@@ -110,6 +110,8 @@ public class GitPropertiesFileTest extends GitIntegrationTest {
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.committer.time"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.author.time"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.closest.tag.name"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.closest.tag.commit.count"));

--- a/maven/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
@@ -99,6 +99,8 @@ public class NaivePerformanceTest extends GitIntegrationTest {
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.author.time"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.committer.time"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
   }
 }

--- a/maven/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/maven/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -43,6 +43,8 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest {
     "git.commit.message.full",
     "git.commit.message.short",
     "git.commit.time",
+    "git.commit.author.time",
+    "git.commit.committer.time",
     "git.total.commit.count",
     "git.remote.origin.url",
     "git.local.branch.ahead",


### PR DESCRIPTION
### Context
Adds support for getting the properties `git.commit.time.author` and `git.commit.time.committer`.

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
