### PR TITLE
Drop support for Java 8, Java 9 and Java 10 + Drop Maven 3.0.x

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         java_version: ['11']
-        maven_version: ['3.0', '3.0.5', '3.1.1', '3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.1']
+        maven_version: ['3.1.1', '3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
           java-package: jdk
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         java_allow_illegal_access: [false]
-        java_version: ['8', '9', '10', '11', '12', '13', '14', '15']
+        java_version: ['11', '12', '13', '14', '15']
         include:
           - java_version: '16'
             java_allow_illegal_access: true
@@ -64,7 +64,7 @@ jobs:
     needs: checkstyle
     strategy:
       matrix:
-        java_version: ['8']
+        java_version: ['11']
         maven_version: ['3.0', '3.0.5', '3.1.1', '3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.1']
 
     steps:
@@ -119,11 +119,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git checkout "${GITHUB_REF:11}"
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
           java-package: jdk
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -142,11 +142,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
           java-package: jdk
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Plugin compatibility with Java
 | 2.2.X           | Java 1.7              |
 | 3.0.0           | Java 1.8              |
 | 4.0.0           | Java 1.8              |
+| 5.0.0           | Java 11               |
 
 
 Plugin compatibility with Maven
@@ -52,18 +53,27 @@ Even though this plugin tries to be compatible with every Maven version there ar
 
 | Maven Version               | Plugin Version  | Notes                                                                                                           |
 | --------------------------- | ---------------:|:---------------------------------------------------------------------------------------------------------------:|
-| Maven 2.0.11                | up to 2.2.6     | Maven 2 is EOL, git-commit-id-plugin:1.0 doesn't work -- requires maven version 2.2.1                           |
-| Maven 2.2.1                 | up to 2.2.6     | Maven 2 is EOL                                                                                                  |
-| Maven 3.0.X                 | any             | git-commit-id-plugin:2.1.14, 2.1.15, 2.2.0, 2.2.1, 2.2.3  doesn't work  -- requires maven version 3.1.1         |
-| Maven 3.0.X                 | any             | For git-commit-id-plugin 2.2.4 or higher: works, but failed to load class "org.slf4j.impl.StaticLoggerBinder"   |
 | Maven 3.1.0                 | any             | git-commit-id-plugin:2.1.14, 2.1.15, 2.2.0, 2.2.1, 2.2.3 doesn't work -- requires maven version 3.1.1           |
 | Maven 3.3.1                 | any             | git-commit-id-plugin:2.1.14 doesn't work                                                                        |
 | Maven 3.3.3                 | any             | git-commit-id-plugin:2.1.14 doesn't work                                                                        |
-| Maven 3.X.X                 | any             | Any other non listed version here should work with any plugin version                                           |
+| Maven 3.X.X (3.0.X is EOL)  | any             | Any other non listed version here should work with any plugin version                                           |
 
 
 Note:
 As an example -- this table should be read as: For `Maven 3.1.0` `any` Plugin Version should work, besides the ones listed in the `Notes` have the limitations listed.
+
+Plugin compatibility with EOL Maven version
+-----------------------------
+End of life (EOL) Maven versions are no longer supported by Maven, nor this plugin.
+The following information is made available for reference.
+
+| Maven Version               | Plugin Version  | Notes                                                                                                           |
+| --------------------------- | ---------------:|:---------------------------------------------------------------------------------------------------------------:|
+| Maven 2.0.11                | up to 2.2.6     | Maven 2 is EOL, git-commit-id-plugin:1.0 doesn't work -- requires maven version 2.2.1                           |
+| Maven 2.2.1                 | up to 2.2.6     | Maven 2 is EOL                                                                                                  |
+| Maven 3.0.X                 | up to 4.0.5     | git-commit-id-plugin:2.1.14, 2.1.15, 2.2.0, 2.2.1, 2.2.3  doesn't work  -- requires maven version 3.1.1         |
+| Maven 3.0.X                 | up to 4.0.5     | For git-commit-id-plugin 2.2.4 or higher: works, but failed to load class "org.slf4j.impl.StaticLoggerBinder"   |
+
 
 Getting SNAPSHOT versions of the plugin
 ---------------------------------------

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.target>1.8</java.target>
+        <java.target>11</java.target>
 
         <jgit.version>5.12.0.202106070339-r</jgit.version>
         <junit.version>4.13.2</junit.version>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -29,7 +29,7 @@
 
     <java.target>11</java.target>
 
-    <maven-plugin-api.version>3.0</maven-plugin-api.version>
+    <maven-plugin-api.version>3.1.0-alpha-1</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
     <junit.version>4.13.2</junit.version>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -27,7 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <java.target>1.8</java.target>
+    <java.target>11</java.target>
 
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
                     <source>8</source>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java.target>1.8</java.target>
+        <java.target>11</java.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
