### PR TITLE
#458: Have the plugin operate in "offline mode" by default

### DIFF
--- a/core/src/main/java/pl/project13/core/AheadBehind.java
+++ b/core/src/main/java/pl/project13/core/AheadBehind.java
@@ -23,6 +23,10 @@ import java.util.Objects;
  * A local git repository can either be "ahead", or "behind" in the number of commits
  * relative to the remote repository. This class tracks the amount of commits the local git repository
  * is "behind", or "ahead" relative to it's remote.
+ *
+ * :warning: You must set the {@code offline}-setting of the plugin to {@code false} when you want to ensure
+ * that the properties generated are truly up-to-date. Otherwise the local state of the git repository is used
+ * which might be out-of-date.
  */
 public class AheadBehind {
 

--- a/maven/docs/using-the-plugin.md
+++ b/maven/docs/using-the-plugin.md
@@ -308,15 +308,20 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <!-- @since 3.0.1 -->
                     <!--
                         Default (optional):
-                        false
+                        true
 
                         Explanation:
                         When set to `true`, the plugin will not try to contact any remote repositories.
                         Any operations will only use the local state of the repo. If set to `false`, it will
                         execute `git fetch` operations e.g. to determine the `ahead` and `behind` branch
                         information.
+
+                        Warning:
+                        Before version 5.X.X the default was set to `false` causing the plugin to operate
+                        in online-mode by default. Be advised that in offline-mode the plugin might generate
+                        inaccurate `git.local.branch.ahead` and `git.local.branch.behind` branch information.
                     -->
-                    <offline>false</offline>
+                    <offline>true</offline>
 
                     <!-- @since 2.1.12 -->
                     <!--
@@ -899,8 +904,8 @@ Generated properties
  |`git.commit.user.email`        | Represents the user eMail of the user who performed the commit. |
  |`git.commit.user.name`         | Represents the user name of the user who performed the commit. |
  |`git.dirty`                    | A working tree is said to be "dirty" if it contains modifications which have not been committed to the current branch. |
- |`git.local.branch.ahead`       | Represents the count of commits that your local branch is ahead in perspective to the remote branch (usually the case when your local branch has committed changes that are not pushed yet to the remote branch). Note: To obtain the right value for this property this plugin will perform a `git fetch`. |
- |`git.local.branch.behind`      | Represents the count of commits that your local branch is behind in perspective to the remote branch (usually the case when there are commits in the remote branch that are not yet integrated into your local branch). Note: To obtain the right value for this property this plugin will perform a `git fetch`. |
+ |`git.local.branch.ahead`       | Represents the count of commits that your local branch is ahead in perspective to the remote branch (usually the case when your local branch has committed changes that are not pushed yet to the remote branch). Note: To obtain the right value for this property this plugin should operate in online mode (`<offline>false</offline>`) so a `git fetch` will be performed before retrieval. |
+ |`git.local.branch.behind`      | Represents the count of commits that your local branch is behind in perspective to the remote branch (usually the case when there are commits in the remote branch that are not yet integrated into your local branch). Note: To obtain the right value for this property this plugin should operate in online mode (`<offline>false</offline>`) so a `git fetch` will be performed before retrieval. |
  |`git.remote.origin.url`        | Represents the URL of the remote repository for the current git project. |
  |`git.tags`                     | Represents a list of tags which contain the specified commit (`git tag --contains`). |
  |`git.total.commit.count`       | Represents the total count of all commits in the current repository (`git rev-list HEAD --count`). |

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -374,9 +374,13 @@ public class GitCommitIdMojo extends AbstractMojo {
   /**
    * Controls whether the git plugin tries to access remote repos to fetch latest information
    * or only use local information.
+   *
+   * :warning: Before version 5.X.X the default was set to {@code false} causing the plugin to operate
+   * in online-mode by default.
+   *
    * @since 3.0.1
    */
-  @Parameter(defaultValue = "false")
+  @Parameter(defaultValue = "true")
   boolean offline;
 
   /**


### PR DESCRIPTION
#458: Have the plugin operate in "offline mode" by default to prevent issues like "com.jcraft.jsch.JSchException: Auth fail" 

WARNING: the properties `git.local.branch.ahead` and `git.local.branch.behind` might be inaccurate without `<offline>false</offline>`!

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
