### PR TITLE
#465: relocate the group-id and artifact-id of the maven-plugin

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="git-commit-id-plugin" location=".github/.checkstyle/google_checks_checkstyle_8.2.xml" type="project" description="">
+  <local-check-config name="git-commit-id-maven-plugin" location=".github/.checkstyle/google_checks_checkstyle_8.2.xml" type="project" description="">
     <additional-data name="protect-config-file" value="false"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="git-commit-id-plugin" local="true">
+  <fileset name="all" enabled="true" check-config-name="git-commit-id-maven-plugin" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
 </fileset-config>

--- a/.github/.checkstyle/java.header
+++ b/.github/.checkstyle/java.header
@@ -1,16 +1,16 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 In general pull requests and support for open issues is always welcome!
 
 ## Project layout
-This project is a multi-module Maven project. It consists of the following modules:
-- [core](core) (`git-commit-id-plugin-core`): The core framework of the plugin
-- [maven](maven) (`git-commit-id-plugin`): The actual plugin, which depends on the `core` module
+This project is a Maven project which currently consists of the following:
+- [git-commit-id-plugin-core](https://github.com/git-commit-id/git-commit-id-plugin-core) (`git-commit-id-plugin-core`): The core framework of the plugin
+- [git-commit-id-maven-plugin](https://github.com/git-commit-id/git-commit-id-maven-plugin) (`git-commit-id-maven-plugin`): The actual (maven) plugin, which depends on the `core` module
 
 To build the project:
 1. Install Maven

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ maven git commit id plugin
 
 [![Build Status](https://secure.travis-ci.org/git-commit-id/git-commit-id-maven-plugin.svg?branch=master)](https://travis-ci.org/github/git-commit-id/git-commit-id-maven-plugin)
 [![Coverage Status](https://coveralls.io/repos/github/git-commit-id/git-commit-id-maven-plugin/badge.svg?branch=master)](https://coveralls.io/github/git-commit-id/git-commit-id-maven-plugin?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.project13.maven/git-commit-id-plugin/badge.svg)](https://search.maven.org/artifact/pl.project13.maven/git-commit-id-plugin)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.git-commit-id/git-commit-id-maven-plugin/badge.svg)](https://search.maven.org/artifact/io.github.git-commit-id/git-commit-id-maven-plugin)
 
 
-git-commit-id-plugin is a plugin quite similar to [Build Number Maven Plugin](https://www.mojohaus.org/buildnumber-maven-plugin/index.html) for example but as the Build Number plugin at the time when I started this plugin only supported CVS and SVN, something had to be done.
+git-commit-id-maven-plugin is a plugin quite similar to [Build Number Maven Plugin](https://www.mojohaus.org/buildnumber-maven-plugin/index.html) for example but as the Build Number plugin at the time when I started this plugin only supported CVS and SVN, something had to be done.
 I had to quickly develop a Git version of such a plugin. For those who don't know the plugin, it basically helps you with the following tasks and answers related questions
 * Which version had the bug? Is that deployed already?
 * Make your distributed deployment aware of versions
@@ -25,16 +25,29 @@ Quicklinks (all relevant documentation)
 
 Getting the plugin
 ==================
-The plugin **is available from Maven Central** ([see here](https://search.maven.org/artifact/pl.project13.maven/git-commit-id-plugin)), so you don't have to configure any additional repositories to use this plugin.
+The plugin **is available from Maven Central** ([see here](https://search.maven.org/artifact/io.github.git-commit-id/git-commit-id-maven-plugin)), so you don't have to configure any additional repositories to use this plugin.
 
 A detailed description of using the plugin is available in the [Using the plugin](docs/using-the-plugin.md) document. All you need to do in the basic setup is to include that plugin definition in your `pom.xml`.
 For more advanced users we also prepared a [guide to provide a brief overview of the more advanced configurations](docs/using-the-plugin.md)... read on!
+
+Relocation of the Project
+------------------------
+Newer version (5.x.x or more recent) are available via
+```xml
+<groupId>io.github.git-commit-id</groupId>
+<artifactId>git-commit-id-maven-plugin</artifactId>
+```
+older version (4.x.x or older) are available via:
+```xml
+<groupId>pl.project13.maven</groupId>
+<artifactId>git-commit-id-plugin</artifactId>
+``` 
 
 Versions
 --------
 The current version is **4.0.5** ([changelist](https://github.com/git-commit-id/git-commit-id-maven-plugin/issues?q=milestone%3A4.0.5)).
 
-You can check the available versions by visiting [search.maven.org](https://search.maven.org/artifact/pl.project13.maven/git-commit-id-plugin), though using the newest is obviously the best choice.
+You can check the available versions by visiting [search.maven.org](https://search.maven.org/artifact/io.github.git-commit-id/git-commit-id-maven-plugin), though using the newest is obviously the best choice.
 
 Plugin compatibility with Java
 -------------------------------
@@ -85,10 +98,13 @@ But I highly recommend using only stable versions, from Maven Central... :-)
     <pluginRepository>
         <id>sonatype-snapshots</id>
         <name>Sonatype Snapshots</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
     </pluginRepository>
 </pluginRepositories>
 ```
+
+Older Snapshots (prior version 5.X) are available via `<url>https://oss.sonatype.org/content/repositories/snapshots/</url>`.
+
 
 If you just would like to see what the plugin can do, you can clone the repository and run
 ```

--- a/docs/using-the-plugin-in-more-depth.md
+++ b/docs/using-the-plugin-in-more-depth.md
@@ -116,7 +116,7 @@ import org.codehaus.jackson.annotate.JsonWriteNullProperties;
 /**
 * A spring controlled bean that will be injected
 * with properties about the repository state at build time.
-* This information is supplied by my plugin - <b>pl.project13.maven.git-commit-id-plugin</b>
+* This information is supplied by my plugin - <b>pl.project13.maven.git-commit-id-maven-plugin</b>
 */
 @JsonWriteNullProperties(true)
 public class GitRepositoryState {

--- a/docs/using-the-plugin.md
+++ b/docs/using-the-plugin.md
@@ -11,9 +11,9 @@ For more in-depth explanation of all options read the next section.
 
 ```xml
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.0</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -72,9 +72,9 @@ It's really simple to setup this plugin; below is a sample pom that you may base
 
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.0</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -341,7 +341,7 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         the plugin only generate the file in the project build directory which is the first one
                         based on the execution graph (!).
 
-                        Important: Please note that the git-commit-id-plugin also has an option to skip pom
+                        Important: Please note that the git-commit-id-maven-plugin also has an option to skip pom
                         project (`<packaging>pom</packaging>`). If you plan to use the `runOnlyOnce` option
                         alongside with an aggregator pom you may want to set `<skipPoms>false</skipPoms>`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                         <configuration>
                             <trimStackTrace>false</trimStackTrace>
                             <!-- Workaround for https://github.com/stefanbirkner/system-lambda/issues/23 -->
-                            <argLine>--illegal-access=permit --add-opens=java.base/java.util.jar=ALL-UNNAMED</argLine>
+                            <argLine>--illegal-access=permit --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                         <configuration>
                             <trimStackTrace>false</trimStackTrace>
                             <!-- Workaround for https://github.com/stefanbirkner/system-lambda/issues/23 -->
-                            <argLine>--illegal-access=permit --add-opens java.base/jdk.internal.loader=ALL-UNNAMED</argLine>
+                            <argLine>--illegal-access=permit --add-opens=java.base/java.util.jar=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>git-commit-id-plugin-core</artifactId>
-                <version>${project.version}</version>
+                <version>5.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                         <configuration>
                             <trimStackTrace>false</trimStackTrace>
                             <!-- Workaround for https://github.com/stefanbirkner/system-lambda/issues/23 -->
-                            <argLine>--illegal-access=permit</argLine>
+                            <argLine>--illegal-access=permit --add-opens java.base/jdk.internal.loader=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -378,8 +378,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>pl.project13.maven</groupId>
-                        <artifactId>git-commit-id-plugin</artifactId>
+                        <groupId>io.github.git-commit-id</groupId>
+                        <artifactId>git-commit-id-maven-plugin</artifactId>
                         <version>${project.version}</version>
                         <!-- optional to change the phases of the individual mojo's -->
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
         <version>9</version>
     </parent>
 
-    <groupId>pl.project13.maven</groupId>
-    <artifactId>git-commit-id-plugin</artifactId>
+    <groupId>io.github.git-commit-id</groupId>
+    <artifactId>git-commit-id-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>5.0.0-SNAPSHOT</version>
     <name>Git Commit Id Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         </pluginManagement>
 
         <plugins>
-            <!-- if you would like to run the git-commit-id-plugin for your build, you could also include it here instead using a profile (see README.md) -->
+            <!-- if you would like to run the git-commit-id-maven-plugin for your build, you could also include it here instead using a profile (see README.md) -->
             <!-- Setting built-in java compiler properties -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
+++ b/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;
@@ -35,7 +35,7 @@ public class PropertiesReplacer {
    * Constructor to encapsulates all references required to perform property replacements.
    * @param log The logger to log any messages
    * @param expressionEvaluator Maven's PluginParameterExpressionEvaluator
-   *                            (see https://github.com/git-commit-id/maven-git-commit-id-plugin/issues/413 why it's needed)
+   *                            (see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/413 why it's needed)
    */
   public PropertiesReplacer(LoggerBridge log, PluginParameterExpressionEvaluator expressionEvaluator) {
     this.log = log;

--- a/src/main/java/pl/project13/maven/git/ReplacementProperty.java
+++ b/src/main/java/pl/project13/maven/git/ReplacementProperty.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/main/java/pl/project13/maven/git/TransformationRule.java
+++ b/src/main/java/pl/project13/maven/git/TransformationRule.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;
@@ -29,7 +29,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * set to {@code AFTER} to have the rule being applied after the replacement.
  * The {@code action}-tag determines the string conversion rule that should be applied.
  *
- * Refer to https://github.com/ktoso/maven-git-commit-id-plugin/issues/317 for a use-case.
+ * Refer to https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/317 for a use-case.
  */
 public class TransformationRule {
   /**

--- a/src/main/java/pl/project13/maven/log/MavenLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/log/MavenLoggerBridge.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.log;

--- a/src/main/java/pl/project13/maven/validation/ValidationMojo.java
+++ b/src/main/java/pl/project13/maven/validation/ValidationMojo.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.validation;

--- a/src/main/java/pl/project13/maven/validation/ValidationProperty.java
+++ b/src/main/java/pl/project13/maven/validation/ValidationProperty.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.validation;

--- a/src/test/java/pl/project13/core/GitDataProviderTest.java
+++ b/src/test/java/pl/project13/core/GitDataProviderTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core;

--- a/src/test/java/pl/project13/core/JgitProviderAheadBehindTest.java
+++ b/src/test/java/pl/project13/core/JgitProviderAheadBehindTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core;

--- a/src/test/java/pl/project13/core/NativeProviderAheadBehindTest.java
+++ b/src/test/java/pl/project13/core/NativeProviderAheadBehindTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core;

--- a/src/test/java/pl/project13/core/PropertiesFileGeneratorTest.java
+++ b/src/test/java/pl/project13/core/PropertiesFileGeneratorTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core;

--- a/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
+++ b/src/test/java/pl/project13/core/UriUserInfoRemoverTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core;

--- a/src/test/java/pl/project13/core/jgit/DescribeCommandAbbrevIntegrationTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeCommandAbbrevIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/core/jgit/DescribeCommandOptionsTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeCommandOptionsTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/core/jgit/DescribeCommandTagsIntegrationTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeCommandTagsIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/core/jgit/DescribeResultTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeResultTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/core/jgit/JGitCommonIntegrationTest.java
+++ b/src/test/java/pl/project13/core/jgit/JGitCommonIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.core.jgit;

--- a/src/test/java/pl/project13/maven/git/AheadBehindTest.java
+++ b/src/test/java/pl/project13/maven/git/AheadBehindTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/BigDiffTest.java
+++ b/src/test/java/pl/project13/maven/git/BigDiffTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
+++ b/src/test/java/pl/project13/maven/git/GitPropertiesFileTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
+++ b/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
+++ b/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/PropertiesFiltererTest.java
+++ b/src/test/java/pl/project13/maven/git/PropertiesFiltererTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/git/PropertiesReplacerTest.java
+++ b/src/test/java/pl/project13/maven/git/PropertiesReplacerTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.git;

--- a/src/test/java/pl/project13/maven/validation/ValidationMojoTest.java
+++ b/src/test/java/pl/project13/maven/validation/ValidationMojoTest.java
@@ -1,18 +1,18 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-maven-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * git-commit-id-maven-plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package pl.project13.maven.validation;

--- a/src/test/resources/git.properties
+++ b/src/test/resources/git.properties
@@ -1,18 +1,18 @@
 #
-# This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+# This file is part of git-commit-id-maven-plugin by Konrad Malawski <konrad.malawski@java.pl>
 #
-# git-commit-id-plugin is free software: you can redistribute it and/or modify
+# git-commit-id-maven-plugin is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# git-commit-id-plugin is distributed in the hope that it will be useful,
+# git-commit-id-maven-plugin is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+# along with git-commit-id-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 git.branch=${git.branch}


### PR DESCRIPTION
relocate the maven-plugin from 
```xml
<groupId>pl.project13.maven</groupId>
<artifactId>git-commit-id-plugin</artifactId>
``` 
to 
```xml
<groupId>io.github.git-commit-id</groupId>
<artifactId>git-commit-id-maven-plugin</artifactId>
```

See https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/465 for details.

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
