### PR TITLE
make use of git-commit-id-plugin-core:6.0.0-rc.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>git-commit-id-plugin-core</artifactId>
-                <version>5.0.1-SNAPSHOT</version>
+                <version>6.0.0-rc.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -666,7 +666,7 @@ public class GitCommitIdMojo extends AbstractMojo {
             // this should only be null in our tests
             if (buildContext != null) {
               buildContext.refresh(file);
-            };
+            }
           };
         }
 


### PR DESCRIPTION
Requirement to fix https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/590