### PR TITLE
Bring plugins up to date, fix 2 javadoc issues, Require maven 3.2.5

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         java_version: ['11']
-        maven_version: ['3.1.0-alpha-1', '3.1.1', '3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.1', '4.0.0-alpha-5']
+        maven_version: ['3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.1', '3.9.2', '4.0.0-alpha-5']
 
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <java.target>11</java.target>
 
-        <maven-plugin-api.version>3.9.0</maven-plugin-api.version>
+        <maven-plugin-api.version>3.9.2</maven-plugin-api.version>
         <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
 
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <!-- GIT COMMIT ID PLUGIN CONFIGURATION -->
         <resources>
             <resource>
-                <directory>src/main/resources</directory>
+                <directory>${project.basedir}/src/main/resources</directory>
                 <filtering>true</filtering>
                 <includes>
                     <include>**/*.properties</include>
@@ -86,7 +86,7 @@
         </resources>
         <testResources>
             <testResource>
-                <directory>src/test/resources</directory>
+                <directory>${project.basedir}/src/test/resources</directory>
                 <excludes>
                     <exclude>_git_*/**</exclude>
                     <exclude>README.md</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </description>
 
     <prerequisites>
-        <maven>[3.1.0-alpha-1,)</maven>
+        <maven>[3.2.5,)</maven>
     </prerequisites>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,16 @@
         </pluginManagement>
 
         <plugins>
+            <!-- Override oss parent downgrades -->
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+
             <!-- if you would like to run the git-commit-id-maven-plugin for your build, you could also include it here instead using a profile (see README.md) -->
             <!-- Setting built-in java compiler properties -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,6 @@
                             </dependency>
                         </dependencies>
                     </plugin>
-                    <!-- cobertura-maven-plugin doesn't support java 8 https://github.com/mojohaus/cobertura-maven-plugin/issues/21-->
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </description>
 
     <prerequisites>
-        <maven>[${maven-plugin-api.version},)</maven>
+        <maven>[3.1.0-alpha-1,)</maven>
     </prerequisites>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -451,9 +451,9 @@
                         <dependencies>
                             <!-- https://github.com/trautonen/coveralls-maven-plugin/issues/141 -->
                             <dependency>
-                                <groupId>javax.xml.bind</groupId>
-                                <artifactId>jaxb-api</artifactId>
-                                <version>2.2.3</version>
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>2.3.3</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -110,15 +110,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
@@ -126,15 +126,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
@@ -146,7 +146,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -158,7 +158,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
@@ -444,9 +444,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.eluder.coveralls</groupId>
+                        <groupId>io.jsonwebtoken.coveralls</groupId>
                         <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.3.0</version>
+                        <version>4.4.1</version>
                         <!-- repo token is passed via -DrepoToken=yourcoverallsprojectrepositorytoken -->
                         <dependencies>
                             <!-- https://github.com/trautonen/coveralls-maven-plugin/issues/141 -->
@@ -460,7 +460,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
+                        <version>0.8.10</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>
@@ -476,7 +476,7 @@
         <profile>
             <id>checkstyle</id>
             <properties>
-                <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+                <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
                 <!--  if you update the checkstyle version make sure you update the google_checks.xml inside the repository -->
                 <checkstyle.version>8.25</checkstyle.version>
                 <checkstyle.config.path>${basedir}/.github/.checkstyle</checkstyle.config.path>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 
         <java.target>11</java.target>
 
-        <maven-plugin-api.version>3.1.0-alpha-1</maven-plugin-api.version>
-        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+        <maven-plugin-api.version>3.9.0</maven-plugin-api.version>
+        <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
 
         <junit.version>4.13.2</junit.version>
         <mockito.version>5.1.1</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>9</version>
+        <relativePath />
     </parent>
 
     <groupId>io.github.git-commit-id</groupId>

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -927,8 +927,8 @@ public class GitCommitIdMojo extends AbstractMojo {
    * of the input/output property.
    * This behaviour can be achieved by defining a list of {@code transformationRules} for
    * the property where those rules should take effect.
-   * Each {@code transformationRule} consist of two required fields {@cdoe apply} and {@code action}.
-   * The {@cdoe apply}-tag controls when the rule should be applied and can be set to {@code BEFORE}
+   * Each {@code transformationRule} consist of two required fields {@code apply} and {@code action}.
+   * The {@code apply}-tag controls when the rule should be applied and can be set to {@code BEFORE}
    * to have the rule being applied before or it can be set to {@code AFTER} to have the
    * rule being applied after the replacement.
    * The {@code action}-tag determines the string conversion rule that should be applied.


### PR DESCRIPTION
Brought all plugins up to date.  Adjusted the min maven so it can still run tests to confirm really old end of life maven versions still work.  Not this work is important given maven 3.9.0+ requirements and upcoming maven 4.

The release process will still complain with warnings if using maven 3.9.x.  This has to do with profiles in oss parent that should be removed and directly used as that is long obsolete as stated by nexus.  For now left it with just the in-line build plugins being fully addressed.

It would further be nice to get a release shortly after this although I see possibly some larger change for 6.x, possible that can drop back and be released or go as-is.  Either way this plugin current is vocal due to maven changes which only can be resolved by being up to date and releasing new version.

One note: while GHA works, I was entirely unable to build locally using windows before I even touched any updates.  Tests simply do not work, guessing some other setup must exist first as it complained in regards to the following....


```
Caused by: java.io.FileNotFoundException: File system element for parameter 'source' does not exist: 'src\test\resources\_git_one_commit'
```

All seem similar and there is no file in that location.