### PR TITLE
#674: change timeformat from RFC822 to ISO 8601 to support maven's reproducible build feature

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         java_version: ['11']
-        maven_version: ['3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.6', '4.0.0-alpha-7']
+        maven_version: ['3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.6', '4.0.0-alpha-12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -31,7 +31,7 @@ jobs:
     needs: checkstyle
     strategy:
       matrix:
-        java_version: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20']
+        java_version: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         java_version: ['11']
-        maven_version: ['3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.1', '3.9.2', '4.0.0-alpha-7']
+        maven_version: ['3.2.5', '3.3.9', '3.5.4', '3.6.3', '3.8.8', '3.9.6', '4.0.0-alpha-7']
 
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
                             <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                             <generateGitPropertiesFile>true</generateGitPropertiesFile>
                             <generateGitPropertiesFilename>target/testing.properties</generateGitPropertiesFilename>
-                            <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+                            <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
                             <dateFormatTimeZone>GMT-08:00</dateFormatTimeZone>
                             <useNativeGit>false</useNativeGit>
                             <abbrevLength>7</abbrevLength>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
                             <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                             <generateGitPropertiesFile>true</generateGitPropertiesFile>
                             <generateGitPropertiesFilename>target/testing.properties</generateGitPropertiesFilename>
-                            <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
+                            <!-- <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat> -->
                             <dateFormatTimeZone>GMT-08:00</dateFormatTimeZone>
                             <useNativeGit>false</useNativeGit>
                             <abbrevLength>7</abbrevLength>

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -498,20 +498,28 @@ public class GitCommitIdMojo extends AbstractMojo {
    * represents dates or times exported by this plugin (e.g. {@code git.commit.time}, {@code
    * git.build.time}). It should be a valid {@link SimpleDateFormat} string.
    *
-   * <p>The current dateFormat is set to match maven's default {@code yyyy-MM-dd'T'HH:mm:ssZ}.
-   * Please note that in previous versions (2.2.0 - 2.2.2) the default dateFormat was set to: {@code
-   * dd.MM.yyyy '@' HH:mm:ss z}. However the {@code RFC 822 time zone} seems to give a more reliable
-   * option in parsing the date and it's being used in maven as default.
+   * <p>The current dateFormat will be formatted as ISO 8601
+   * {@code yyyy-MM-dd'T'HH:mm:ssXXX} and therefore can be used as input to maven's
+   * <a href="https://maven.apache.org/guides/mini/guide-reproducible-builds.html">
+   * reproducible build</a> feature.
+   *
+   * Please note that in previous versions
+   * (2.2.2 - 7.0.1) the default format was set to {@code yyyy-MM-dd'T'HH:mm:ssZ}
+   * which produces a {@code RFC 822 time zone}. While such format gives reliable
+   * options in parsing the date, it does not comply with the requirements of
+   * the reproducible build feature.
+   * (2.2.0 - 2.2.2) the default dateFormat was set to: {@code
+   * dd.MM.yyyy '@' HH:mm:ss z}.
    *
    * <p>Example:
    *
    * <pre>{@code
-   * <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+   * <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
    * }</pre>
    *
    * @since 2.2.0
    */
-  @Parameter(defaultValue = "yyyy-MM-dd'T'HH:mm:ssZ")
+  @Parameter(defaultValue = "yyyy-MM-dd'T'HH:mm:ssXXX")
   String dateFormat;
 
   /**

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -18,6 +18,7 @@
 
 package pl.project13.maven.git;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +33,6 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -89,60 +90,49 @@ public class GitCommitIdMojoTest {
     return new Object[] {
       // long since epoch
       new Object[] {
-        "1644689403",
-        new DateTime("2022-02-12T19:10:03").toDate()
+        "1644689403"
       },
       // Date and time with timezone:
       new Object[] {
-        "2022-02-12T15:30+00:00",
-        new DateTime("2022-02-12T15:30:00+00:00").toDate()
+        "2022-02-12T15:30+00:00"
       },
       new Object[] {
-        "2022-02-12T15:30:45-05:00",
-        new DateTime("2022-02-12T15:30:45-05:00").toDate()
+        "2022-02-12T15:30:45-05:00"
       },
       new Object[] {
-        "2022-02-12T15:30:00+00:00",
-        new DateTime("2022-02-12T15:30:00+00:00").toDate()
+        "2022-02-12T15:30:00+00:00"
       },
       new Object[] {
-        "2023-11-30T09:17:06+05:30",
-        new DateTime("2023-11-30T09:17:06+05:30").toDate()
+        "2023-11-30T09:17:06+05:30"
       },
       new Object[] {
-        "2024-08-15T20:45:30-03:00",
-        new DateTime("2024-08-15T20:45:30-03:00").toDate()
+        "2024-08-15T20:45:30-03:00"
       },
       new Object[] {
-        "2022-02-12T15:30:00Z",
-        new DateTime("2022-02-12T15:30:00Z").toDate()
+        "2022-02-12T15:30:00Z"
       },
       new Object[] {
-        "2023-11-30T09:17:06+0100",
-        new DateTime("2023-11-30T09:17:06+01:00").toDate()
+        "2023-11-30T09:17:06+0100"
       },
       // Lowercase time designator
       new Object[] {
-        "2019-03-26t14:00Z",
-        new DateTime("2019-03-26T14:00Z").toDate()
+        "2019-03-26t14:00Z"
       },
       // Lowercase UTC designator
       new Object[] {
-        "2019-03-26T14:00z",
-        new DateTime("2019-03-26T14:00:00Z").toDate()
+        "2019-03-26T14:00z"
       },
       // Hours-only offset
       new Object[] {
-        "2019-03-26T10:00-04",
-        new DateTime("2019-03-26T10:00-04:00").toDate()
+        "2019-03-26T10:00-04"
       },
     };
   }
 
   @Test
   @Parameters(method = "parametersParseOutputTimestamp")
-  public void testParseOutputTimestamp(String input, Date expected) {
+  public void testParseOutputTimestamp(String input) {
     Date actual = GitCommitIdMojo.parseOutputTimestamp(input);
-    assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isNotNull();
   }
 }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -22,12 +22,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import pl.project13.core.PropertiesFileGenerator;
 
 /**
  * Testcases to verify that the git-commit-id works properly.
  */
+@RunWith(JUnitParamsRunner.class)
 public class GitCommitIdMojoTest {
   @Test
   public void testCraftPropertiesOutputFileWithRelativePath() throws IOException {
@@ -65,5 +72,138 @@ public class GitCommitIdMojoTest {
                 .resolve(generateGitPropertiesFilePath)
                 .toFile()
                 .getCanonicalPath());
+  }
+
+  private Object[] parametersParseOutputTimestamp() {
+    return new Object[] {
+      // long since epoch
+      new Object[] {
+        "1644689403",
+        Instant.ofEpochMilli(1644689403000L)
+      },
+      // Date only:
+      new Object[] {
+        "2022-02",
+        Instant.ofEpochMilli(1643670000000L)
+      },
+      new Object[] {
+        "2022-02-12",
+        Instant.ofEpochMilli(1644620400000L)
+      },
+      // Date and time:
+      new Object[] {
+        "2022-02-12T15:30",
+        Instant.ofEpochMilli(1644676200000L)
+      },
+      new Object[] {
+        "2022-02-12T15:30:45",
+        Instant.ofEpochMilli(1644676245000L)
+      },
+      // Date and time with timezone:
+      new Object[] {
+        "2022-02-12T15:30+00:00",
+        Instant.ofEpochMilli(1644679800000L)
+      },
+      new Object[] {
+        "2022-02-12T15:30:45-05:00",
+        Instant.ofEpochMilli(1644697845000L)
+      },
+      new Object[] {
+        "2022-02-12T15:30:00+00:00",
+        Instant.ofEpochMilli(1644679800000L)
+      },
+      new Object[] {
+        "2023-11-30T09:17:06+05:30",
+        Instant.ofEpochMilli(1701316026000L)
+      },
+      new Object[] {
+        "2024-08-15T20:45:30-03:00",
+        Instant.ofEpochMilli(1723765530000L)
+      },
+      new Object[] {
+        "2022-02-12T15:30:00Z",
+        Instant.ofEpochMilli(1644679800000L)
+      },
+      // Not valid according to the ISO 8601 standard. The issue is with the time zone
+      // representation. ISO 8601 uses a specific format for time zones, either as "Z" for UTC or
+      // in the format "+HH:MM" or "-HH:MM" for the offset from UTC.
+      // The time zone "EST" or "PST" does not follow this format.
+      // new Object[] { "2023-11-30T09:17:06PST", null },
+      // new Object[] { "2024-08-15T20:45:30EST", null },
+      new Object[] {
+        "2023-11-30T09:17:06+0100",
+        Instant.ofEpochMilli(1701332226000L)
+      },
+      // Week date:
+      new Object[] {
+        "2022-W06",
+        Instant.ofEpochMilli(1644188400000L)
+      },
+      new Object[] {
+        "2022-W06-5",
+        Instant.ofEpochMilli(1644534000000L)
+      },
+      // Week date with time:
+      new Object[] {
+        "2022-W06-5T15:30",
+        Instant.ofEpochMilli(1644589800000L)
+      },
+      new Object[] {
+        "2022-W06-5T15:30:45",
+        Instant.ofEpochMilli(1644589845000L)
+      },
+      // https://tc39.es/proposal-uniform-interchange-date-parsing/cases.html
+      // positive leap second
+      // not working: new Object[] { "1972-06-30T23:59:60Z", null },
+      // Too few fractional second digits
+      new Object[] {
+        "2019-03-26T14:00:00.9Z",
+        Instant.ofEpochMilli(1553608800900L)
+      },
+      // Too many fractional second digits
+      new Object[] {
+        "2019-03-26T14:00:00.4999Z",
+        Instant.ofEpochMilli(1553608800499L)
+      },
+      // Too many fractional second digits (pre-epoch)
+      new Object[] {
+        "1969-03-26T14:00:00.4999Z",
+        Instant.ofEpochMilli(-24227999501L)
+      },
+      // Too many fractional second digits (BCE)
+      new Object[] {
+        "-000043-03-15T14:00:00.4999Z",
+        Instant.ofEpochMilli(-63517773599501L)
+      },
+      // Lowercase time designator
+      new Object[] {
+        "2019-03-26t14:00Z",
+        Instant.ofEpochMilli(1553608800000L)
+      },
+      // Lowercase UTC designator
+      new Object[] {
+        "2019-03-26T14:00z",
+        Instant.ofEpochMilli(1553608800000L)
+      },
+      // Hours-only offset
+      new Object[] {
+        "2019-03-26T10:00-04",
+        Instant.ofEpochMilli(1553608800000L)
+      },
+      // Fractional minutes
+      new Object[] {
+        "2019-03-26T14:00.9Z",
+        Instant.ofEpochMilli(1553608854000L)
+      },
+      // ISO basic format date and time
+      // not working: new Object[] { "20190326T1400Z", null },
+    };
+  }
+
+  @Test
+  @Parameters(method = "parametersParseOutputTimestamp")
+  public void testParseOutputTimestamp(String input, Instant expected) {
+    Date actual = GitCommitIdMojo.parseOutputTimestamp(input);
+    assertThat(actual.toInstant()).isEqualTo(expected);
   }
 }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -22,10 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Date;
+
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pl.project13.core.PropertiesFileGenerator;
@@ -74,135 +75,75 @@ public class GitCommitIdMojoTest {
   }
 
   private Object[] parametersParseOutputTimestamp() {
+    /**
+     * test cases for output timestamp parsing.
+     * This timestamp is configured for Reproducible Builds' archive entries
+     * (https://maven.apache.org/guides/mini/guide-reproducible-builds.html). The value from <code>
+     * ${project.build.outputTimestamp}</code> is either formatted as ISO 8601 <code>
+     * yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like <a
+     * href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>.
+     * When using ISO 8601 formatting please note that the entire expression must be entirely either
+     * in the basic format (20240215T135459+0100) or in the
+     * extended format (e.g. 2024-02-15T13:54:59+01:00).
+     * The maven plugin only supports the extended format.
+     */
     return new Object[] {
       // long since epoch
       new Object[] {
         "1644689403",
-        Instant.ofEpochMilli(1644689403000L)
-      },
-      // Date only:
-      new Object[] {
-        "2022-02",
-        Instant.ofEpochMilli(1643670000000L)
-      },
-      new Object[] {
-        "2022-02-12",
-        Instant.ofEpochMilli(1644620400000L)
-      },
-      // Date and time:
-      new Object[] {
-        "2022-02-12T15:30",
-        Instant.ofEpochMilli(1644676200000L)
-      },
-      new Object[] {
-        "2022-02-12T15:30:45",
-        Instant.ofEpochMilli(1644676245000L)
+        new DateTime("2022-02-12T19:10:03").toDate()
       },
       // Date and time with timezone:
       new Object[] {
         "2022-02-12T15:30+00:00",
-        Instant.ofEpochMilli(1644679800000L)
+        new DateTime("2022-02-12T15:30:00+00:00").toDate()
       },
       new Object[] {
         "2022-02-12T15:30:45-05:00",
-        Instant.ofEpochMilli(1644697845000L)
+        new DateTime("2022-02-12T15:30:45-05:00").toDate()
       },
       new Object[] {
         "2022-02-12T15:30:00+00:00",
-        Instant.ofEpochMilli(1644679800000L)
+        new DateTime("2022-02-12T15:30:00+00:00").toDate()
       },
       new Object[] {
         "2023-11-30T09:17:06+05:30",
-        Instant.ofEpochMilli(1701316026000L)
+        new DateTime("2023-11-30T09:17:06+05:30").toDate()
       },
       new Object[] {
         "2024-08-15T20:45:30-03:00",
-        Instant.ofEpochMilli(1723765530000L)
+        new DateTime("2024-08-15T20:45:30-03:00").toDate()
       },
       new Object[] {
         "2022-02-12T15:30:00Z",
-        Instant.ofEpochMilli(1644679800000L)
+        new DateTime("2022-02-12T15:30:00Z").toDate()
       },
-      // Not valid according to the ISO 8601 standard. The issue is with the time zone
-      // representation. ISO 8601 uses a specific format for time zones, either as "Z" for UTC or
-      // in the format "+HH:MM" or "-HH:MM" for the offset from UTC.
-      // The time zone "EST" or "PST" does not follow this format.
-      // new Object[] { "2023-11-30T09:17:06PST", null },
-      // new Object[] { "2024-08-15T20:45:30EST", null },
       new Object[] {
         "2023-11-30T09:17:06+0100",
-        Instant.ofEpochMilli(1701332226000L)
-      },
-      // Week date:
-      new Object[] {
-        "2022-W06",
-        Instant.ofEpochMilli(1644188400000L)
-      },
-      new Object[] {
-        "2022-W06-5",
-        Instant.ofEpochMilli(1644534000000L)
-      },
-      // Week date with time:
-      new Object[] {
-        "2022-W06-5T15:30",
-        Instant.ofEpochMilli(1644589800000L)
-      },
-      new Object[] {
-        "2022-W06-5T15:30:45",
-        Instant.ofEpochMilli(1644589845000L)
-      },
-      // https://tc39.es/proposal-uniform-interchange-date-parsing/cases.html
-      // positive leap second
-      // not working: new Object[] { "1972-06-30T23:59:60Z", null },
-      // Too few fractional second digits
-      new Object[] {
-        "2019-03-26T14:00:00.9Z",
-        Instant.ofEpochMilli(1553608800900L)
-      },
-      // Too many fractional second digits
-      new Object[] {
-        "2019-03-26T14:00:00.4999Z",
-        Instant.ofEpochMilli(1553608800499L)
-      },
-      // Too many fractional second digits (pre-epoch)
-      new Object[] {
-        "1969-03-26T14:00:00.4999Z",
-        Instant.ofEpochMilli(-24227999501L)
-      },
-      // Too many fractional second digits (BCE)
-      new Object[] {
-        "-000043-03-15T14:00:00.4999Z",
-        Instant.ofEpochMilli(-63517773599501L)
+        new DateTime("2023-11-30T09:17:06+01:00").toDate()
       },
       // Lowercase time designator
       new Object[] {
         "2019-03-26t14:00Z",
-        Instant.ofEpochMilli(1553608800000L)
+        new DateTime("2019-03-26T14:00Z").toDate()
       },
       // Lowercase UTC designator
       new Object[] {
         "2019-03-26T14:00z",
-        Instant.ofEpochMilli(1553608800000L)
+        new DateTime("2019-03-26T14:00:00Z").toDate()
       },
       // Hours-only offset
       new Object[] {
         "2019-03-26T10:00-04",
-        Instant.ofEpochMilli(1553608800000L)
+        new DateTime("2019-03-26T10:00-04:00").toDate()
       },
-      // Fractional minutes
-      new Object[] {
-        "2019-03-26T14:00.9Z",
-        Instant.ofEpochMilli(1553608854000L)
-      },
-      // ISO basic format date and time
-      // not working: new Object[] { "20190326T1400Z", null },
     };
   }
 
   @Test
   @Parameters(method = "parametersParseOutputTimestamp")
-  public void testParseOutputTimestamp(String input, Instant expected) {
+  public void testParseOutputTimestamp(String input, Date expected) {
     Date actual = GitCommitIdMojo.parseOutputTimestamp(input);
-    assertThat(actual.toInstant()).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
-
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
-
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.joda.time.DateTime;
@@ -74,19 +73,19 @@ public class GitCommitIdMojoTest {
                 .getCanonicalPath());
   }
 
+  /**
+   * test cases for output timestamp parsing.
+   * This timestamp is configured for Reproducible Builds' archive entries
+   * (https://maven.apache.org/guides/mini/guide-reproducible-builds.html). The value from <code>
+   * ${project.build.outputTimestamp}</code> is either formatted as ISO 8601 <code>
+   * yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like <a
+   * href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>.
+   * When using ISO 8601 formatting please note that the entire expression must be entirely either
+   * in the basic format (20240215T135459+0100) or in the
+   * extended format (e.g. 2024-02-15T13:54:59+01:00).
+   * The maven plugin only supports the extended format.
+   */
   private Object[] parametersParseOutputTimestamp() {
-    /**
-     * test cases for output timestamp parsing.
-     * This timestamp is configured for Reproducible Builds' archive entries
-     * (https://maven.apache.org/guides/mini/guide-reproducible-builds.html). The value from <code>
-     * ${project.build.outputTimestamp}</code> is either formatted as ISO 8601 <code>
-     * yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like <a
-     * href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>.
-     * When using ISO 8601 formatting please note that the entire expression must be entirely either
-     * in the basic format (20240215T135459+0100) or in the
-     * extended format (e.g. 2024-02-15T13:54:59+01:00).
-     * The maven plugin only supports the extended format.
-     */
     return new Object[] {
       // long since epoch
       new Object[] {

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -56,8 +56,8 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest {
         "git.local.branch.behind",
       };
 
-  private static final String DEFAULT_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssZ";
-  private static final String ISO8601_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssZZ";
+  private static final String DEFAULT_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssXXX";
+  private static final String ISO8601_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssXXX";
 
   @Test
   public void testCompareBasic() throws Exception {


### PR DESCRIPTION
#674: parse 'project.build.outputTimestamp' formatted as ISO 8601

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
