### PR TITLE
Only injects properties into every reactor project once

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -1234,6 +1234,17 @@ public class GitCommitIdMojo extends AbstractMojo {
         commitIdPropertiesOutputFormat = CommitIdPropertiesOutputFormat.PROPERTIES;
       }
 
+      Properties properties = null;
+      // check if properties have already been injected
+      Properties contextProperties = getContextProperties(project);
+      boolean alreadyInjected = injectAllReactorProjects && contextProperties != null;
+      if (alreadyInjected) {
+        log.info(
+                "injectAllReactorProjects is enabled - attempting to use the already computed values");
+        // makes sure the existing context properties are not mutated
+        properties = new Properties(contextProperties);
+      }
+
       final GitCommitIdPlugin.Callback cb =
           new GitCommitIdPlugin.Callback() {
             @Override
@@ -1339,7 +1350,7 @@ public class GitCommitIdMojo extends AbstractMojo {
 
             @Override
             public void performPublishToAllSystemEnvironments(Properties properties) {
-              publishToAllSystemEnvironments(getLogInterface(), properties);
+          publishToAllSystemEnvironments(getLogInterface(), properties, contextProperties);
             }
 
             @Override
@@ -1393,29 +1404,27 @@ public class GitCommitIdMojo extends AbstractMojo {
             }
           };
 
-      Properties properties = null;
-      // check if properties have already been injected
-      Properties contextProperties = getContextProperties(project);
-      boolean alreadyInjected = injectAllReactorProjects && contextProperties != null;
-      if (alreadyInjected) {
-        log.info(
-            "injectAllReactorProjects is enabled - attempting to use the already computed values");
-        properties = contextProperties;
-      }
-
       GitCommitIdPlugin.runPlugin(cb, properties);
     } catch (GitCommitIdExecutionException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }
   }
 
-  private void publishToAllSystemEnvironments(LogInterface log, Properties propertiesToPublish) {
+  private void publishToAllSystemEnvironments(LogInterface log, Properties propertiesToPublish, Properties contextProperties) {
     publishPropertiesInto(propertiesToPublish, project.getProperties());
     // some plugins rely on the user properties (e.g. flatten-maven-plugin)
     publishPropertiesInto(propertiesToPublish, session.getUserProperties());
 
     if (injectAllReactorProjects) {
-      appendPropertiesToReactorProjects(log, propertiesToPublish);
+      Properties diffPropertiesToPublish = new Properties();
+      propertiesToPublish.forEach((k, v) -> {
+          if (!contextProperties.contains(k)) {
+              diffPropertiesToPublish.setProperty(k.toString(), v.toString());
+          }
+      });
+      if(!diffPropertiesToPublish.isEmpty()) {
+          appendPropertiesToReactorProjects(log, diffPropertiesToPublish);
+      }
     }
 
     if (injectIntoSysProperties) {
@@ -1479,7 +1488,7 @@ public class GitCommitIdMojo extends AbstractMojo {
   private void appendPropertiesToReactorProjects(LogInterface log, Properties propertiesToPublish) {
     for (MavenProject mavenProject : reactorProjects) {
       log.debug("Adding properties to project: '" + mavenProject.getName() + "'");
-
+      if(mavenProject.equals(project)) continue;
       publishPropertiesInto(propertiesToPublish, mavenProject.getProperties());
       mavenProject.setContextValue(CONTEXT_KEY, propertiesToPublish);
     }


### PR DESCRIPTION
### Context
Enabling `injectAllReactorProjects` in large and old reactor projects allows to avoid repeatedly parsing the git history to retrieve the information.

In the apache/james-project enabling this property allowed to lower the time spent in git-commit-id from 39s[1] to 2s[2].

However, looking at the verbose logs one can see that the plugin keeps injecting the properties into every reactor project for every project where the plugin runs.

This commit aims to avoid reinjecting keys which have already been set in the context.

[1] https://ge.apache.org/s/xumcl7ztpkmhw/timeline?collapse-all&outcome=success,failed&view=by-type
[2] https://ge.apache.org/s/gpnevfknmdv5a/timeline?collapse-all&hide-timeline&outcome=success,failed&view=by-type

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`

I'm not saying the fix is perfect, but hopefully it illustrates the issue. If you want a sample project to reproduce you can look at https://github.com/apache/james-project/ enabling verbose output on git-commit-id you will be able to see that for every single project the plugin reinjects all the properties in the 273 projects of the reactor ... effectively setting the properties 273*273 =74529 times.
The performance impact is not huge since its all in memory accesses but it still feels quite wasteful