### PR TITLE
use gpg profile on release, not sonatype-oss-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,9 @@
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <arguments>-Pgpg</arguments>
+                </configuration>
             </plugin>
 
             <!-- if you would like to run the git-commit-id-maven-plugin for your build, you could also include it here instead using a profile (see README.md) -->


### PR DESCRIPTION
### Context
investigating Reproducible Builds issue https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/io/github/git-commit-id/README.md

### Contributor Checklist
see `mvn help:effective-pom -Dverbose -Psonatype-oss-release`
vs `mvn help:effective-pom -Dverbose -Pgpg`
particularly at maven-source-plugin level