### PR TITLE
Use javac `--release` instead of `-source` & `-target`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,8 +217,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${java.target}</source>
-                    <target>${java.target}</target>
+                    <release>${java.target}</release>
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Context
`--release` also verifies that only API from that Java version is used. Otherwise when building with a JDK newer than the target version it would be possible to accidentally use API not available in the target version.

This also fixes this warning which is currently printed during the build:
> [WARNING] system modules path not set in conjunction with -source 11

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
