### PR TITLE
#754: Fix an issue where empty git.properties had been generated in submodules when injectAllReactorProjects=true

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -1486,7 +1486,9 @@ public class GitCommitIdMojo extends AbstractMojo {
 
   private void appendPropertiesToReactorProjects(LogInterface log, Properties propertiesToPublish) {
     for (MavenProject mavenProject : reactorProjects) {
-      log.debug("Adding '" + propertiesToPublish.size() + "' properties to project: '" + mavenProject.getName() + "'");
+      log.debug(
+          "Adding '" + propertiesToPublish.size() + "' properties "
+          + "to project: '" + mavenProject.getName() + "'");
       if (mavenProject.equals(project)) {
         continue;
       }
@@ -1494,8 +1496,8 @@ public class GitCommitIdMojo extends AbstractMojo {
       mavenProject.setContextValue(CONTEXT_KEY, propertiesToPublish);
     }
     log.info(
-      "Added '" + propertiesToPublish.size() + "' properties " +
-      "to '" + reactorProjects.size() + "' projects");
+        "Added '" + propertiesToPublish.size() + "' properties "
+        + "to '" + reactorProjects.size() + "' projects");
   }
 
   private void logProperties(LogInterface log, Properties propertiesToPublish) {

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -1145,6 +1145,7 @@ public class GitCommitIdMojo extends AbstractMojo {
             || PropertiesFileGenerator.craftPropertiesOutputFile(
                     project.getBasedir(), new File(generateGitPropertiesFilename))
                 .exists()) {
+          log.info("Skip mojo execution on incremental builds.");
           return;
         }
       }
@@ -1237,7 +1238,8 @@ public class GitCommitIdMojo extends AbstractMojo {
         log.info(
             "injectAllReactorProjects is enabled - attempting to use the already computed values");
         // makes sure the existing context properties are not mutated
-        properties = new Properties(contextProperties);
+        properties = new Properties();
+        properties.putAll(contextProperties);
       }
 
       final GitCommitIdPlugin.Callback cb =
@@ -1484,14 +1486,16 @@ public class GitCommitIdMojo extends AbstractMojo {
 
   private void appendPropertiesToReactorProjects(LogInterface log, Properties propertiesToPublish) {
     for (MavenProject mavenProject : reactorProjects) {
-      log.debug("Adding properties to project: '" + mavenProject.getName() + "'");
+      log.debug("Adding '" + propertiesToPublish.size() + "' properties to project: '" + mavenProject.getName() + "'");
       if (mavenProject.equals(project)) {
         continue;
       }
       publishPropertiesInto(propertiesToPublish, mavenProject.getProperties());
       mavenProject.setContextValue(CONTEXT_KEY, propertiesToPublish);
     }
-    log.info("Added properties to '" + reactorProjects.size() + "' projects");
+    log.info(
+      "Added '" + propertiesToPublish.size() + "' properties " +
+      "to '" + reactorProjects.size() + "' projects");
   }
 
   private void logProperties(LogInterface log, Properties propertiesToPublish) {


### PR DESCRIPTION

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
