### PR TITLE
bump io.github.git-commit-id:git-commit-id-plugin-core from 6.1.5 to 6.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>git-commit-id-plugin-core</artifactId>
-                <version>6.1.5</version>
+                <version>6.2.0</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-                <optional>true</optional>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -326,8 +325,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
         </dependency>
 
         <!-- dependencies to annotations -->

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -24,6 +24,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -31,8 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
@@ -44,7 +44,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
-import org.joda.time.DateTime;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.sonatype.plexus.build.incremental.BuildContext;
 import pl.project13.core.CommitIdGenerationMode;
 import pl.project13.core.CommitIdPropertiesOutputFormat;
@@ -1279,25 +1280,25 @@ public class GitCommitIdMojo extends AbstractMojo {
               return () -> project.getVersion();
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public LogInterface getLogInterface() {
               return log;
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public String getDateFormat() {
               return dateFormat;
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public String getDateFormatTimeZone() {
               return dateFormatTimeZone;
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public String getPrefixDot() {
               String trimmedPrefix = prefix.trim();
@@ -1443,8 +1444,8 @@ public class GitCommitIdMojo extends AbstractMojo {
   }
 
   private void publishToAllSystemEnvironments(
-      @Nonnull LogInterface log,
-      @Nonnull Properties propertiesToPublish,
+      @NonNull LogInterface log,
+      @NonNull Properties propertiesToPublish,
       @Nullable Properties contextProperties) {
     publishPropertiesInto(propertiesToPublish, project.getProperties());
     // some plugins rely on the user properties (e.g. flatten-maven-plugin)
@@ -1505,7 +1506,44 @@ public class GitCommitIdMojo extends AbstractMojo {
       // no timestamp configured
       return null;
     }
-    return new DateTime(outputTimestamp).toDate();
+    // Normalize the timestamp to handle common variations
+    String normalized = outputTimestamp.trim();
+
+    // Handle lowercase designators
+    normalized = normalized.replace('t', 'T').replace('z', 'Z');
+
+    // Handle hours-only offsets by adding :00 minutes if needed
+    if (normalized.matches(".*[+-]\\d{2}$")) {
+      normalized = normalized.substring(0, normalized.length() - 3)
+              + normalized.substring(normalized.length() - 3) + ":00";
+    }
+
+    // Try parsing with different formatters in order of preference
+    DateTimeFormatter[] formatters = {
+      DateTimeFormatter.ISO_INSTANT,                           // 2022-02-12T15:30:00Z
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME,                  // 2022-02-12T15:30+00:00
+      DateTimeFormatter.ISO_LOCAL_DATE_TIME,                   // 2022-02-12T15:30:00
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmZ"),      // 2019-03-26T10:00-0400
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"),   // 2019-03-26T10:00:00-0400
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")        // 2022-02-12T15:30
+    };
+
+    for (DateTimeFormatter formatter : formatters) {
+      try {
+        if (
+            formatter == DateTimeFormatter.ISO_LOCAL_DATE_TIME
+            &&
+            (normalized.contains("+") || normalized.contains("-") || normalized.endsWith("Z"))
+        ) {
+          continue; // Skip local formatter for timestamps with timezones
+        }
+        return Date.from(Instant.from(formatter.parse(normalized)));
+      } catch (DateTimeParseException ignore) {
+        // Try next formatter
+      }
+    }
+
+    throw new IllegalArgumentException("Unable to parse timestamp: " + outputTimestamp);
   }
 
   private void publishPropertiesInto(Properties propertiesToPublish, Properties propertiesTarget) {
@@ -1536,7 +1574,7 @@ public class GitCommitIdMojo extends AbstractMojo {
     }
   }
 
-  private boolean isPomProject(@Nonnull MavenProject project) {
+  private boolean isPomProject(@NonNull MavenProject project) {
     return project.getPackaging().equalsIgnoreCase("pom");
   }
 }

--- a/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
+++ b/src/test/java/pl/project13/core/jgit/DescribeCommandIntegrationTest.java
@@ -26,12 +26,12 @@ import static org.mockito.Mockito.spy;
 
 import java.util.Collections;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import pl.project13.log.DummyTestLoggerBridge;
 import pl.project13.maven.git.AvailableGitTestRepo;
@@ -448,11 +448,11 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     }
   }
 
-  String abbrev(@Nonnull String id) {
+  String abbrev(@NonNull String id) {
     return abbrev(id, DEFAULT_ABBREV_LEN);
   }
 
-  String abbrev(@Nonnull String id, int n) {
+  String abbrev(@NonNull String id, int n) {
     return id.substring(0, n);
   }
 }

--- a/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
@@ -19,7 +19,7 @@
 package pl.project13.maven.git;
 
 import java.io.File;
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * List of available git repositories that we can use to perform tests with.
@@ -168,7 +168,7 @@ public enum AvailableGitTestRepo {
     this.dir = dir;
   }
 
-  @Nonnull
+  @NonNull
   public File getDir() {
     return new File(dir);
   }

--- a/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
@@ -19,8 +19,8 @@
 package pl.project13.maven.git;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.assertj.core.api.Condition;
+import org.jspecify.annotations.NonNull;
 
 class ContainsKeyCondition extends Condition<Map<?, ?>> {
 
@@ -31,7 +31,7 @@ class ContainsKeyCondition extends Condition<Map<?, ?>> {
   }
 
   @Override
-  public boolean matches(@Nonnull Map<?, ?> map) {
+  public boolean matches(@NonNull Map<?, ?> map) {
     boolean containsKey = map.containsKey(key);
     if (!containsKey) {
       throw new RuntimeException(

--- a/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
@@ -19,8 +19,8 @@
 package pl.project13.maven.git;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.assertj.core.api.Condition;
+import org.jspecify.annotations.NonNull;
 
 class DoesNotContainKeyCondition extends Condition<Map<?, ?>> {
 
@@ -31,7 +31,7 @@ class DoesNotContainKeyCondition extends Condition<Map<?, ?>> {
   }
 
   @Override
-  public boolean matches(@Nonnull Map<?, ?> map) {
+  public boolean matches(@NonNull Map<?, ?> map) {
     boolean containsKey = map.containsKey(key);
     if (containsKey) {
       System.out.println(String.format("Map contained [%s] key! Map is: %s", key, map));

--- a/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -21,10 +21,10 @@ package pl.project13.maven.git;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Quick and dirty maven projects tree structure to create on disk during integration tests. Can
@@ -50,20 +50,20 @@ public class FileSystemMavenSandbox {
     this.rootSandboxPath = rootSandboxPath;
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox withParentProject(String parentProjectDirName, String packaging) {
     parentProject =
         createProject(new File(rootSandboxPath + File.separator + parentProjectDirName), packaging);
     return this;
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox withNoChildProject() {
     // no-op: marker for better tests readability
     return this;
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox withChildProject(String childProjectDirName, String packaging) {
     childProject =
         createProject(new File(parentProject.getBasedir(), childProjectDirName), packaging);
@@ -71,8 +71,8 @@ public class FileSystemMavenSandbox {
     return this;
   }
 
-  @Nonnull
-  public FileSystemMavenSandbox withGitRepoInParent(@Nonnull AvailableGitTestRepo repo) {
+  @NonNull
+  public FileSystemMavenSandbox withGitRepoInParent(@NonNull AvailableGitTestRepo repo) {
     System.out.println("TEST: Will prepare sandbox repository based on: [" + repo.getDir() + "]");
 
     gitRepoSourceDir = repo.getDir();
@@ -80,27 +80,27 @@ public class FileSystemMavenSandbox {
     return this;
   }
 
-  @Nonnull
-  public FileSystemMavenSandbox withGitRepoInChild(@Nonnull AvailableGitTestRepo repo) {
+  @NonNull
+  public FileSystemMavenSandbox withGitRepoInChild(@NonNull AvailableGitTestRepo repo) {
     gitRepoSourceDir = repo.getDir();
     gitRepoTargetDir = childProject.getBasedir();
     return this;
   }
 
-  @Nonnull
-  public FileSystemMavenSandbox withGitRepoAboveParent(@Nonnull AvailableGitTestRepo repo) {
+  @NonNull
+  public FileSystemMavenSandbox withGitRepoAboveParent(@NonNull AvailableGitTestRepo repo) {
     gitRepoSourceDir = repo.getDir();
     gitRepoTargetDir = new File(rootSandboxPath);
     return this;
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox withNoGitRepoAvailable() {
     gitRepoTargetDir = null;
     return this;
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox create() throws RuntimeException {
     try {
       createParentDir();
@@ -145,7 +145,7 @@ public class FileSystemMavenSandbox {
     return childProject;
   }
 
-  @Nonnull
+  @NonNull
   private MavenProject createProject(File basedir, String packaging) {
     MavenProject project = new MavenProject();
     project.setFile(new File(basedir + File.separator + "pom.xml"));
@@ -166,7 +166,7 @@ public class FileSystemMavenSandbox {
         + '}';
   }
 
-  @Nonnull
+  @NonNull
   public FileSystemMavenSandbox withKeepSandboxWhenFinishedTest(
       boolean keepSandboxWhenFinishedTest) {
     // if we want to keep the generated sandbox for overwiew the content of it

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -18,7 +18,6 @@
 
 package pl.project13.maven.git;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -27,18 +26,17 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.eclipse.jgit.api.Git;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
@@ -115,8 +113,8 @@ public abstract class GitIntegrationTest {
     return Optional.empty();
   }
 
-  @Nonnull
-  protected File dotGitDir(@Nonnull Optional<String> projectDir) {
+  @NonNull
+  protected File dotGitDir(@NonNull Optional<String> projectDir) {
     if (projectDir.isPresent()) {
       return new File(currSandbox + File.separator + projectDir.get() + File.separator + ".git");
     } else {
@@ -143,7 +141,7 @@ public abstract class GitIntegrationTest {
     mojo.settings = mockSettings();
   }
 
-  public void setProjectToExecuteMojoIn(@Nonnull MavenProject project) {
+  public void setProjectToExecuteMojoIn(@NonNull MavenProject project) {
     mojo.project = project;
     mojo.dotGitDirectory = new File(project.getBasedir(), ".git");
     mojo.reactorProjects = getReactorProjects(project);
@@ -162,7 +160,7 @@ public abstract class GitIntegrationTest {
     return settings;
   }
 
-  private static List<MavenProject> getReactorProjects(@Nonnull MavenProject project) {
+  private static List<MavenProject> getReactorProjects(@NonNull MavenProject project) {
     List<MavenProject> reactorProjects = new ArrayList<>();
     MavenProject mavenProject = project;
     while (mavenProject != null) {

--- a/src/test/java/pl/project13/maven/jgit/DescribeCommandAbbrevIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/jgit/DescribeCommandAbbrevIntegrationTest.java
@@ -21,9 +21,9 @@ package pl.project13.maven.jgit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import pl.project13.core.jgit.DescribeCommand;
 import pl.project13.core.jgit.DescribeResult;
@@ -113,7 +113,7 @@ public class DescribeCommandAbbrevIntegrationTest extends GitIntegrationTest {
     }
   }
 
-  String abbrev(@Nonnull String id, int n) {
+  String abbrev(@NonNull String id, int n) {
     return id.substring(0, n);
   }
 }


### PR DESCRIPTION
See https://github.com/git-commit-id/git-commit-id-plugin-core/releases/tag/v6.2.0
- replace `org.eclipse.jgit.ssh.jsch` with `org.eclipse.jgit:org.eclipse.jgit.ssh.apache` (see https://github.com/eclipse-jgit/jgit/blob/master/org.eclipse.jgit.ssh.jsch/README.md)
- add `org.bouncycastle:bcpkix-jdk18on` version `1.81`
- remove `joda-time:joda-time` [replaced with Java 8+ Time API]
- replace `com.google.code.findbugs:jsr305` version `3.0.2` with `org.jspecify:jspecify` version `1.0.0`

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
