### PR TITLE
#913: Require Maven 3.9.0 [Maven 3.6.3 is EOL]

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         java_version: ['11']
-        maven_version: ['3.6.3', '3.8.8', '3.9.9', '4.0.0-alpha-13', '4.0.0-beta-5', '4.0.0-rc-2']
+        maven_version: ['3.9.0', '3.9.9', '4.0.0-alpha-13', '4.0.0-beta-5', '4.0.0-rc-5']
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The plugin is **available from [Maven Central](https://central.sonatype.com/arti
 
 ## Minimum Requirements
 * Java 11
-* Maven 3.6.3
+* Maven 3.9.0
 
 ## Documentation
 * [Use Cases](docs/use-cases.md)

--- a/docs/old-versions.md
+++ b/docs/old-versions.md
@@ -37,6 +37,7 @@ Even though this plugin tries to be compatible with every Maven version there ar
 | 7.X.X          |                        Maven 3.2.5                         |
 | 8.X.X          |                        Maven 3.2.5                         |
 | 9.X.X          |                        Maven 3.6.3                         |
+| 10.X.X         |                        Maven 3.9.0                         |
 
 Flipping the table to maven:
 Please note that in theory maven 4.X should support all maven 3 plugins.

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </developers>
 
     <prerequisites>
-        <maven>[3.6.3,)</maven>
+        <maven>[3.9.0,)</maven>
     </prerequisites>
 
     <licenses>


### PR DESCRIPTION
https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/913

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
